### PR TITLE
fix size comp method output #539

### DIFF
--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -4270,7 +4270,7 @@ FUNCTION void write_bigoutput()
             else
             {s_off = 1;}
             // Yr Month Seas Subseas Time Fleet Area Repl. Sexes Kind Part Ageerr Sex Lbin_lo Lbin_hi Bin Obs Exp
-            SS_compout << SzFreq_obs_hdr(iobs, 1) << " " << real_month << " " << Show_Time2(ALK_time)(2, 3) << " " << data_time(ALK_time, f, 3) << " " << f << " " << fleet_area(f) << " " << repli << " " << gg << " SIZE " << p << " " << k;
+            SS_compout << SzFreq_obs_hdr(iobs, 1) << " " << real_month << " " << Show_Time2(ALK_time)(2, 3) << " " << data_time(ALK_time, f, 3) << " " << f << " " << fleet_area(f) << " " << repli << " " << gg << " SIZE " << p << " " << Sz_method;
             SS_compout << " " << s_off << " " << SzFreq_units(Sz_method) << " " << SzFreq_scale(Sz_method) << " ";
             if (s_off == 1)
             {


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.
Fixes bad value reported for size comp method (in Ageerr column of CompReport.sso)

* Resolves issue #539

## What tests have been done? 
### Where are the relevant files?
Running with simple_small_sizecomp model (attached to issue #539) now produces CompReport.sso file with size comp method values that match 3.30.19 output.

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->

## Is there an input change for users to Stock Synthesis? 
No.