### PR TITLE
allow custom output filenames

### DIFF
--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -214,8 +214,8 @@ jobs:
           mkdir SS330
           mv Compile/ss.exe SS330/
           mv Compile/ss_opt.exe SS330/
-          mv SS330/ss.exe SS330/ss_win.exe
-          mv SS330/ss_opt.exe SS330/ss_opt_win.exe
+          mv SS330/ss.exe SS330/ss3_win.exe
+          mv SS330/ss_opt.exe SS330/ss3_opt_win.exe
 
       - name: Build stock synthesis for mac
         if: matrix.config.os == 'macos-latest'
@@ -246,8 +246,8 @@ jobs:
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss_opt.tpl
-          mv ss ss_osx
-          mv ss_opt ss_opt_osx
+          mv ss ss3_osx
+          mv ss_opt ss3_opt_osx
           
       - name: Verify binary on linux
         if: matrix.config.os == 'ubuntu-latest'
@@ -260,8 +260,8 @@ jobs:
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss_opt.tpl ss.tpl
-          mv ss ss_linux
-          mv ss_opt ss_opt_linux
+          mv ss ss3_linux
+          mv ss_opt ss3_opt_linux
 
       - name: Archive binaries
         if: success()

--- a/.github/workflows/run-ss3-mcmc.yml
+++ b/.github/workflows/run-ss3-mcmc.yml
@@ -75,7 +75,7 @@ jobs:
           for (i in 1:niters) {
             message("Running iteration ", i)
             # run simple model
-            system("./ss  -maxfn 0 -phase 40 -nohess -mcmc 10 -nuts -mcseed 1 -max_treedepth 3")
+            system("./ss3  -maxfn 0 -phase 40 -nohess -mcmc 10 -nuts -mcseed 1 -max_treedepth 3")
             # read in adaption.csv
             adapt_df <- read.csv("adaptation.csv")
             if(i == 1) {

--- a/.github/workflows/run-ss3-mcmc.yml
+++ b/.github/workflows/run-ss3-mcmc.yml
@@ -59,17 +59,17 @@ jobs:
           mv test-models-repo/models/Simple/forecast.ss forecast.ss
           mv test-models-repo/models/Simple/control.ss control.ss
           mv test-models-repo/models/Simple/data.ss data.ss
-          mv SS330/ss ss
+          mv SS330/ss ss3
           ls
 
       - name: change permissions on ss exe
-        run: chmod a+x ss
+        run: chmod a+x ss3
 
       - name: run models without estimation
         run: |
           # Run NUTS algorithim in ADMB to make sure still works with stock synthesis
           # run the simple model with -hbf option to get the necessary files
-          system("./ss -hbf")
+          system("./ss3 -hbf")
           # run the simple model 30 times using the NUTS algorithim
           niters <- 100
           for (i in 1:niters) {

--- a/.github/workflows/run-ss3-no-est.yml
+++ b/.github/workflows/run-ss3-no-est.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           repository: 'nmfs-ost/ss3-test-models'
           path: test-models-repo
+          ref: specify-exe-name
 
       - name: Update Ubuntu packages
         run: sudo apt-get update
@@ -116,7 +117,7 @@ jobs:
             # run the models without estimation
             file.remove(file.path(dir, "Report.sso"))
             # see if model finishes without error
-            system(paste0("cd ", dir, " && ../ss3 -stopph 0 -nohess modelname ss")) # may need to change path to ss exe
+            system(paste0("cd ", dir, " && ../ss3 -stopph 0 -nohess modelname ss"))
             model_ran <- file.exists(file.path(dir, "control.ss_new"))
             return(model_ran)
           }

--- a/.github/workflows/run-ss3-no-est.yml
+++ b/.github/workflows/run-ss3-no-est.yml
@@ -62,12 +62,12 @@ jobs:
       - name: move exes, scripts to needed locations
         run: |
           mv test-models-repo/models test-models-repo/model_runs
-          mv SS330/ss test-models-repo/model_runs/ss
+          mv SS330/ss test-models-repo/model_runs/ss3
           mv test-models-repo/.github/r_scripts/run_from_par.R test-models-repo/run_from_par.R
           mv test-models-repo/.github/r_scripts/run_compare_noest.R test-models-repo/run_compare_noest.R
 
       - name: change permissions on ss3 exes
-        run: chmod a+x test-models-repo/model_runs/ss
+        run: chmod a+x test-models-repo/model_runs/ss3
 
       - name: run models without estimation
         run: |
@@ -116,7 +116,7 @@ jobs:
             # run the models without estimation
             file.remove(file.path(dir, "Report.sso"))
             # see if model finishes without error
-            system(paste0("cd ", dir, " && ../ss -stopph 0 -nohess")) # may need to change path to ss exe
+            system(paste0("cd ", dir, " && ../ss3 -stopph 0 -nohess modelname ss")) # may need to change path to ss exe
             model_ran <- file.exists(file.path(dir, "control.ss_new"))
             return(model_ran)
           }

--- a/.github/workflows/run-ss3-no-est.yml
+++ b/.github/workflows/run-ss3-no-est.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           repository: 'nmfs-ost/ss3-test-models'
           path: test-models-repo
-          ref: specify-exe-name
 
       - name: Update Ubuntu packages
         run: sudo apt-get update

--- a/.github/workflows/run-ss3-with-est.yml
+++ b/.github/workflows/run-ss3-with-est.yml
@@ -52,10 +52,10 @@ jobs:
       - name: move exes, scripts to needed locations
         run: |
           mv test-models-repo/models test-models-repo/model_runs
-          mv SS330/ss test-models-repo/model_runs/ss
+          mv SS330/ss test-models-repo/model_runs/ss3
 
       - name: change permissions on ss exes
-        run: chmod a+x test-models-repo/model_runs/ss
+        run: chmod a+x test-models-repo/model_runs/ss3
       
       - name: download R packages for parallel
         run: Rscript -e 'install.packages(c("parallely", "furrr", "future"))'
@@ -80,7 +80,7 @@ jobs:
             file.copy(file.path(dir, "ss.par"), file.path(dir, "ss_ref.par"))
             # run the models with estimation and see if model finishes without error
             message("running ss on ", basename(dir))
-            system(paste0("cd ", dir, " && ../ss -nox"))
+            system(paste0("cd ", dir, " && ../ss3 -nox modelname ss"))
             model_ran <- file.exists(file.path(dir, "control.ss_new"))
             return(model_ran)
           }

--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -25,7 +25,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - name: Checkout ss repo
+      - name: Checkout ss3 repo
         uses: actions/checkout@v3
 
       - name: Checkout models repo
@@ -64,12 +64,12 @@ jobs:
       - name: move exes, scripts to needed locations
         run: |
           mv test-models-repo/models test-models-repo/model_runs
-          mv SS330/ss test-models-repo/model_runs/ss
+          mv SS330/ss test-models-repo/model_runs/ss3
           mv test-models-repo/.github/r_scripts/run_from_par.R test-models-repo/run_from_par.R
           mv test-models-repo/.github/r_scripts/run_compare_noest.R test-models-repo/run_compare_noest.R
 
       - name: change permissions on ss3 exes
-        run: chmod a+x test-models-repo/model_runs/ss
+        run: chmod a+x test-models-repo/model_runs/ss3
 
       - name: run models without estimation
         run: |

--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           repository: 'nmfs-ost/ss3-test-models'
           path: test-models-repo
-          ref: specify-exe-name
 
       - name: install libcurl
         run: |

--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           repository: 'nmfs-ost/ss3-test-models'
           path: test-models-repo
+          ref: specify-exe-name
 
       - name: install libcurl
         run: |

--- a/SS_global.tpl
+++ b/SS_global.tpl
@@ -86,6 +86,7 @@ GLOBALS_SECTION
   adstring_array fleetname;
   adstring ssnew_pathname;
   adstring sso_pathname;
+  adstring base_modelname = "ss3";
   adstring fleetnameread;
   adstring depletion_basis_label;
   adstring F_report_label;

--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -18,15 +18,35 @@ PARAMETER_SECTION
   // set the filename to all ADMB output files to "base_modelname.[ext]"
   //  where base_modelname can be read from command line with command modelname followed by text
   //  e.g.  ss3_win.exe -nohess -stopph 3  modelname ss4you
+  //  if requested modelname.par is not found, then will attempt to read from ss3.par then ss.par
+  //  whatever name is read, the write will be to modelname.par.  Which has default of ss3.par
   ad_comm::adprogram_name = base_modelname;
   echoinput << "Begin setting up parameters" << endl;
   cout << "Begin setting up parameters ... ";
   if (readparfile >= 1)
   {
-    cout << " read parm file" << endl;
     anystring = base_modelname + ".par";
+    cout << " read parm file" << endl;
+
+    ifstream fin(anystring);
+    if(fin.fail() ) {
+      cout << " no find, try ss3.par" << endl;
+      anystring = "ss3.par";
+      ifstream fin(anystring);
+      if(fin.fail() ) {
+      cout << " no find, try ss.par" << endl;
+      anystring = "ss.par";
+      ifstream fin(anystring);
+      if(fin.fail() ) {
+    	  warnstream << "could not find requested parfile " << anystring;
+    	  write_message(FATAL, 0);
+      }
+    }}
+    cout << " found "<<anystring<<endl;
+
     ad_comm::change_pinfile_name(anystring);
   }
+
   maximum_function_evaluations.allocate(func_eval.indexmin(), func_eval.indexmax());
   maximum_function_evaluations = func_eval;
   convergence_criteria.allocate(func_conv.indexmin(), func_conv.indexmax());

--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -15,14 +15,17 @@ PARAMETER_SECTION
 //  SS_Label_Info_5.0.1 #Setup convergence critera and max func evaluations
  LOCAL_CALCS
   // clang-format on
-  // set the filename to all ADMB output files to "ss.[ext]"
-  ad_comm::adprogram_name = "ss";
+  // set the filename to all ADMB output files to "base_modelname.[ext]"
+  //  where base_modelname can be read from command line with command modelname followed by text
+  //  e.g.  ss3_win.exe -nohess -stopph 3  modelname ss4you
+  ad_comm::adprogram_name = base_modelname;
   echoinput << "Begin setting up parameters" << endl;
   cout << "Begin setting up parameters ... ";
   if (readparfile >= 1)
   {
     cout << " read parm file" << endl;
-    ad_comm::change_pinfile_name("ss.par");
+    anystring = base_modelname + ".par";
+    ad_comm::change_pinfile_name(anystring);
   }
   maximum_function_evaluations.allocate(func_eval.indexmin(), func_eval.indexmax());
   maximum_function_evaluations = func_eval;

--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -26,7 +26,7 @@ PARAMETER_SECTION
   if (readparfile >= 1)
   {
     anystring = base_modelname + ".par";
-    cout << " read parm file" << endl;
+    cout << " read parm file: " << anystring << endl;
 
     ifstream fin(anystring);
     if(fin.fail() ) {
@@ -38,7 +38,7 @@ PARAMETER_SECTION
       anystring = "ss.par";
       ifstream fin(anystring);
       if(fin.fail() ) {
-    	  warnstream << "could not find requested parfile " << anystring;
+    	  warnstream << "could not find ss3.par, ss.par, or requested parfile " << base_modelname << ".par";
     	  write_message(FATAL, 0);
       }
     }}

--- a/SS_readstarter.tpl
+++ b/SS_readstarter.tpl
@@ -335,12 +335,37 @@
     echoinput << "read max phase to override starter file's maxphase " << maxI << endl;
   }
 
+  if ((on = option_match(argc, argv, "modelname")) > -1 )
+  {
+    base_modelname = ad_comm::argv[on + 1];
+    echoinput << "read basemodel name to use instead of ss3 " << base_modelname << endl;
+  cout << " base name " << base_modelname << endl;
+  }
+
   SDmode = 1;
   if ((on = option_match(argc, argv, "-nohess")) > -1)
   {
     SDmode = 0;
   }
   echoinput << " -nohess flag (1 means do Hessian): " << SDmode << endl;
+  adstring sw; //  used for reading of ADMB switches from command line
+  mcmcFlag = 0;
+  noest_flag = 0;
+  for (i = 0; i < argc; i++) /* SS_loop: check command line arguments for mcmc commands */
+  {
+    sw = argv[i];
+    j = strcmp(sw, "-mcmc");
+    if (j == 0)
+    {
+      mcmcFlag = 1;
+    }
+    j = strcmp(sw, "-mceval");
+    if (j == 0)
+    {
+      mcmcFlag = 1;
+    }
+  }
+  // clang-format off
 
   // SS_Label_Info_1.2  #Read the starter.ss file
   // SS_Label_Flow  read starter.ss
@@ -375,24 +400,6 @@
           << version_info2 << endl;
   warning << "This file contains warnings, suggestions and notes generated as files are read and processed" << endl
           << endl;
-  adstring sw; //  used for reading of ADMB switches from command line
-  mcmcFlag = 0;
-  noest_flag = 0;
-  for (i = 0; i < argc; i++) /* SS_loop: check command line arguments for mcmc commands */
-  {
-    sw = argv[i];
-    j = strcmp(sw, "-mcmc");
-    if (j == 0)
-    {
-      mcmcFlag = 1;
-    }
-    j = strcmp(sw, "-mceval");
-    if (j == 0)
-    {
-      mcmcFlag = 1;
-    }
-  }
-  // clang-format off
  END_CALCS
 
 


### PR DESCRIPTION
Resolves issue #319 

## What tests have been done? 
ss3.exe -nohess -stopph 3  modelname ss4you

produces expects to read ss4you.par and will write ss4you.par

<-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
test with mcmc

## Is there an input change for users to Stock Synthesis? 
No required change.  Provides option to change filename prefix at command line.
This needs to be documented in command line section of the manual

A new command line argument will set the filename for all ADMB output files to "base_modelname.[ext]"
 where base_modelname can be read from command line with command: modelname followed by the desired name
 e.g.  ss3_win.exe modelname ss4you
When readparfile is used, SS3 will attempt to read ss4you.par.
ss4you will be used as prefix for output files such as ss4you.par and ss4you.cor
if requested modelname.par is not found, then will attempt to read from ss3.par, then ss.par, then will fail with warning.
Whatever name is read, the write will be to modelname.par.
Modelname defaults to ss3.par unless changed by the modelname command.
Which has default of ss3.par.
So, if modelname option is not used and the model reads from ss.par, it will write to ss3.par.
Use of modelname ss will allow writing to ss.par for backward compatibility.


