### PR TITLE
add warning when addtocomp is not > 0

### DIFF
--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -1402,6 +1402,11 @@
         min_tail_L(1, f) = min_tail_L(0, f);
         min_tail_L(2, f) = min_tail_L(0, f);
         *(ad_comm::global_datafile) >> min_comp_L(0, f);
+        if (min_comp_L(0, f) <= 0) {
+          warnstream << "addtocomp input for length comps fleet " << f << 
+          " is " << min_comp_L(0, f) << " but should be > 0 to avoid log(0) in likelihood";
+          write_message(WARN, 0);      
+        }
         min_comp_L(1, f) = min_comp_L(0, f);
         min_comp_L(2, f) = min_comp_L(0, f);
         *(ad_comm::global_datafile) >> CombGender_L(0, f);
@@ -2280,6 +2285,11 @@
       {
         *(ad_comm::global_datafile) >> min_tail_A(f);
         *(ad_comm::global_datafile) >> min_comp_A(f);
+        if (min_comp_A(f) <= 0) {
+          warnstream << "addtocomp input for age comps fleet " << f << 
+          " is " << min_comp_A(f) << " but should be > 0 to avoid log(0) in likelihood";
+          write_message(WARN, 0);      
+        }
         *(ad_comm::global_datafile) >> CombGender_A(f);
         *(ad_comm::global_datafile) >> AccumBin_A(f);
         *(ad_comm::global_datafile) >> Comp_Err_A(f);


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.
A "nan" likelihood in model shared by @akatan999 took some time to debug (traced to age comp likelihoood, then to rows with zero observations for some bins, then to 0 values for `addtocomp` settings).
It's hard to imagine anyone wanting the `addtocomp` to be zero, so adding a warning when this occurs will make debugging this easier.

## What tests have been done? 
Compiled and run on the model that was shared which now produces these warnings:
```
Warning 1 : addtocomp input for age comps fleet 1 is 0 but should be > 0 to avoid log(0) in likelihood
Warning 2 : addtocomp input for age comps fleet 2 is 0 but should be > 0 to avoid log(0) in likelihood
```
- [x] No test files are required for this pull request.
Can be replicated on any model by changing `addtocomp` for length or age data to 0 or negative value.

### What tests/review still need to be done?
Review by @Rick-Methot-NOAA to confirm that this was done correction and should be a warning and not an stop. Also, it could be possible to only warn if there are zero values in the observed or expected comps after addition of `addtocomp` but that would be more challenging to implement. Lastly, I'm not clear on the second argument to `write_message(WARN, 0)`, so would be good to get confirmation that this shouldn't be `write_message(WARN, 1)` instead.

## Is there an input change for users to Stock Synthesis? 
- [x] No, there was no input change.
