### PR TITLE
Add log(Pval) term to lognormal prior

### DIFF
--- a/SS_objfunc.tpl
+++ b/SS_objfunc.tpl
@@ -1569,7 +1569,7 @@ FUNCTION dvariable Get_Prior(const int T, const double& Pmin, const double& Pmax
     {
       if (Pmin > 0.0)
       {
-        Prior_Like = 0.5 * square((log(Pval) - Pr) / Psd);
+        Prior_Like = 0.5 * square((log(Pval) - Pr) / Psd) + log(Pval);
       }
       else
       {
@@ -1581,7 +1581,7 @@ FUNCTION dvariable Get_Prior(const int T, const double& Pmin, const double& Pmax
     case 4: //lognormal with bias correction (from Larry Jacobson)
     {
       if (Pmin > 0.0)
-        Prior_Like = 0.5 * square((log(Pval) - Pr + 0.5 * square(Psd)) / Psd);
+        Prior_Like = 0.5 * square((log(Pval) - Pr + 0.5 * square(Psd)) / Psd) + log(Pval);
       else
       {
         warnstream << "Cannot do prior in log space for parm with min <=0.0";


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.
Add `log(pval)` to negative log prior for lognormal distribution  

## What tests have been done? 
### Where are the relevant files?

### What tests/review still need to be done?

## Is there an input change for users to Stock Synthesis? 
No input change.

## Additional information (optional).
Current negative log prior is of the form `0.5 * square(log(x) - mu)`. Since x is estimated in normal space, an additional term `log(x)` from the lognormal distribution is needed.

Some R code to verify:

```
x <- seq(0.01, 1, 0.005)
logmu <- 0
sd <- 1

# True mode of lognormal distribution
f_x <- dlnorm(x, logmu, sd)
x[which.max(f_x)]

# Discrepancy in the mode of the distribution with SS3 lognormal prior
g_x <- -0.5 * (log(x) - logmu)^2/sd/sd
x[which.max(g_x)]

# Mode from proposed correction matches the answer
h_x <- -0.5 * (log(x) - logmu)^2/sd/sd - log(x)
x[which.max(h_x)]
```