### PR TITLE
Build macos 14

### DIFF
--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+        with:
+          ref: v3.30.22.1
     
     # Set up R
       - name: Set up R, specify rtools version and path for windows

--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-14}
+          - {os: macos-latest}
           - {os: macos-13}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
@@ -60,27 +60,27 @@ jobs:
 
     # Build ADMB for macOS
       - name: clean, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: cd admb && make clean
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           ls
           cd admb && ls
 
       - name: compile admb, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           cd admb && make -j 4
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           cd admb && ls -l
 
       - name: put admb in path, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           sudo mv admb /usr/local/bin
           sudo chmod 755 /usr/local/bin/admb
@@ -131,7 +131,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -143,7 +143,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -235,7 +235,7 @@ jobs:
 
     # Build SS3 for macOS
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           rm -rf SS330
           rm -rf ss3_osx.tar
@@ -245,13 +245,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -17,7 +17,7 @@ jobs:
         config:
           - {os: windows-latest}
           - {os: macos-14}
-          - {os: macos-latest}
+          - {os: macos-13}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
     # Compiling admb and ss3 on all operating systems takes ~30 min
@@ -60,27 +60,27 @@ jobs:
 
     # Build ADMB for macOS
       - name: clean, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: cd admb && make clean
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           ls
           cd admb && ls
 
       - name: compile admb, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           cd admb && make -j 4
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           cd admb && ls -l
 
       - name: put admb in path, mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           sudo mv admb /usr/local/bin
           sudo chmod 755 /usr/local/bin/admb
@@ -131,7 +131,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -143,7 +143,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -235,7 +235,7 @@ jobs:
 
     # Build SS3 for macOS
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           rm -rf SS330
           rm -rf ss3_osx.tar
@@ -245,13 +245,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -17,6 +17,7 @@ jobs:
         config:
           - {os: windows-latest}
           - {os: macos-14}
+          - {os: macos-latest}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
     # Compiling admb and ss3 on all operating systems takes ~30 min
@@ -25,8 +26,6 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
-        with:
-          ref: v3.30.22.1
     
     # Set up R
       - name: Set up R, specify rtools version and path for windows
@@ -61,27 +60,27 @@ jobs:
 
     # Build ADMB for macOS
       - name: clean, mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: cd admb && make clean
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           ls
           cd admb && ls
 
       - name: compile admb, mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           cd admb && make -j 4
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           cd admb && ls -l
 
       - name: put admb in path, mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           sudo mv admb /usr/local/bin
           sudo chmod 755 /usr/local/bin/admb
@@ -132,7 +131,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -144,7 +143,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -236,7 +235,7 @@ jobs:
 
     # Build SS3 for macOS
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           rm -rf SS330
           rm -rf ss3_osx.tar
@@ -246,13 +245,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-latest'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-latest}
+          - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
     # Compiling admb and ss3 on all operating systems takes ~30 min

--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -59,27 +59,27 @@ jobs:
 
     # Build ADMB for macOS
       - name: clean, mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: cd admb && make clean
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           ls
           cd admb && ls
 
       - name: compile admb, mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           cd admb && make -j 4
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           cd admb && ls -l
 
       - name: put admb in path, mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           sudo mv admb /usr/local/bin
           sudo chmod 755 /usr/local/bin/admb
@@ -130,7 +130,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -142,7 +142,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -234,7 +234,7 @@ jobs:
 
     # Build SS3 for macOS
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           rm -rf SS330
           rm -rf ss3_osx.tar
@@ -244,13 +244,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-admb-and-ss3-from-source.yml
+++ b/.github/workflows/build-admb-and-ss3-from-source.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-latest}
+          - {os: macos-14}
           - {os: macos-13}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
@@ -60,27 +60,27 @@ jobs:
 
     # Build ADMB for macOS
       - name: clean, mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: cd admb && make clean
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           ls
           cd admb && ls
 
       - name: compile admb, mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           cd admb && make -j 4
 
       - name: see where admb is, mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           cd admb && ls -l
 
       - name: put admb in path, mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           sudo mv admb /usr/local/bin
           sudo chmod 755 /usr/local/bin/admb
@@ -131,7 +131,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -143,7 +143,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -235,7 +235,7 @@ jobs:
 
     # Build SS3 for macOS
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           rm -rf SS330
           rm -rf ss3_osx.tar
@@ -245,13 +245,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-14' || matrix.config.os == 'macos-13'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -220,7 +220,7 @@ jobs:
           brew install --head colima
           brew unlink qemu
           brew install --HEAD qemu
-          colima start
+          brew services start colima
           docker pull johnoel/admb:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -216,12 +216,13 @@ jobs:
       - name: Build stock synthesis for mac with admb docker image
         if: matrix.config.os == 'macos-13'
         run: |
+          brew update
           brew install docker
-          brew install --head colima
-          brew unlink qemu
-          brew install --HEAD qemu
-          brew services start colima
-          docker pull johnoel/admb:linux
+          brew install colima
+          brew unlink colima
+          curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64 && sudo chmod +x /usr/local/bin/colima
+          colima start --network-address
+          docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330
           rm -rf ss3_osx.tar

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-13}
+          - {os: macos-12}
           - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
@@ -125,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -213,14 +213,28 @@ jobs:
           mv SS330/ss3.exe SS330/ss3_win.exe
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
   
+      # - name: Build stock synthesis for mac with admb docker image
+      #   if: matrix.config.os == 'macos-13'
+      #   run: |
+      #     brew update
+      #     brew install docker
+      #     brew install --head colima || true
+      #     brew link --overwrite python@3.11
+      #     colima start --arch x86_64
+      #     docker pull johnoel/admb-13.2:linux
+
+      #     rm -rf SS330
+      #     rm -rf ss3_osx.tar
+      #     mkdir SS330
+      #     chmod 777 SS330
+      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
+      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
+
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-13'
+        if: matrix.config.os == 'macos-12'
         run: |
-          brew update
           brew install docker
-          brew install --head colima || true
-          brew link --overwrite python@3.11
-          colima start --arch x86_64
+          colima start
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330
@@ -230,7 +244,7 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
-        # colima stop
+          colima stop
 
       - name: Build stock synthesis for mac m2 with admb docker image
         if: matrix.config.os == 'macos-14'
@@ -249,13 +263,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -20,6 +20,7 @@ jobs:
         config:
           - {os: windows-latest}
           - {os: macos-latest}
+          - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
     # was set to 15 and then 30 minutes previously, but compiling admb
@@ -41,7 +42,7 @@ jobs:
       #     Expand-Archive -LiteralPath "D:\a\ss3-source-code\ss3-source-code\admb-13.1.zip" -DestinationPath "D:\a\ss3-source-code\ss3-source-code\"
       #     echo "D:\a\ss3-source-code\ss3-source-code\admb-13.1\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       # - name: checkout admb, mac
-      #   if: matrix.config.os == 'macos-latest'
+      #   if: matrix.config.os == 'macos-latest' 
       #   uses: actions/checkout@v3
       #   with:
       #     repository: admb-project/admb
@@ -110,7 +111,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -124,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -213,7 +214,7 @@ jobs:
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
   
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'
         run: |
           brew install docker
           colima start
@@ -229,13 +230,13 @@ jobs:
           colima stop
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -219,7 +219,7 @@ jobs:
           brew update
           brew install docker
           brew install --HEAD colima || true
-          colima start --arch x86_64
+          colima start --arch aarch64
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330
@@ -230,7 +230,6 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
           colima stop
 
-# brew install --head colima || true (after install docker)
       # - name: Build stock synthesis for mac with admb docker image
       #   if: matrix.config.os == 'macos-12'
       #   run: |

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,8 +218,9 @@ jobs:
         run: |
           brew install docker
           brew install --head colima
-          brew services start colima
-          docker context use colima
+          brew unlink qemu
+          brew install --HEAD qemu
+          colima start
           docker pull johnoel/admb:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -220,7 +220,7 @@ jobs:
           brew install --cask docker
           brew install --HEAD colima
           brew link --overwrite python@3.11
-          colima start --arch aarch64
+          colima start --arch x86_64
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -235,8 +235,6 @@ jobs:
           brew update
           brew install docker
           brew install --head colima
-          brew unlink qemu
-          brew install --HEAD qemu
           colima start --arch x86_64
           docker pull johnoel/admb-13.2:linux
 

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-latest}
+          - {os: macos-13}
           - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
@@ -111,7 +111,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -125,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -214,7 +214,7 @@ jobs:
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
   
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-13'
         run: |
           brew install docker
           colima start
@@ -246,13 +246,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -214,7 +214,7 @@ jobs:
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
   
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-latest'
         run: |
           brew install docker
           colima start
@@ -228,6 +228,24 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
           colima stop
+
+      - name: Build stock synthesis for mac m2 with admb docker image
+        if: matrix.config.os == 'macos-14'
+        run: |
+          brew update
+          brew install docker
+          brew install --head colima
+          brew unlink qemu
+          brew install --HEAD qemu
+          colima start --arch x86_64
+          docker pull johnoel/admb-13.2:linux
+
+          rm -rf SS330
+          rm -rf ss3_osx.tar
+          mkdir SS330
+          chmod 777 SS330
+          /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
+          /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
         if: matrix.config.os == 'macos-latest' || matrix.config.os == 'macos-14'

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,8 +218,9 @@ jobs:
         run: |
           brew update
           brew install docker
-          brew install colima || true
+          brew install --head colima || true
           brew link --overwrite python@3.11
+          colima start
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -217,9 +217,8 @@ jobs:
         if: matrix.config.os == 'macos-13'
         run: |
           brew update
-          brew install --cask docker
+          brew install docker
           brew install --HEAD colima
-          brew link --overwrite python@3.11
           colima start --arch x86_64
           docker pull johnoel/admb-13.2:linux
 

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-12}
+          - {os: macos-13}
           - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
@@ -125,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -213,27 +213,12 @@ jobs:
           mv SS330/ss3.exe SS330/ss3_win.exe
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
   
-      # - name: Build stock synthesis for mac with admb docker image
-      #   if: matrix.config.os == 'macos-13'
-      #   run: |
-      #     brew update
-      #     brew install docker
-      #     brew install --head colima || true
-      #     brew link --overwrite python@3.11
-      #     colima start --arch x86_64
-      #     docker pull johnoel/admb-13.2:linux
-
-      #     rm -rf SS330
-      #     rm -rf ss3_osx.tar
-      #     mkdir SS330
-      #     chmod 777 SS330
-      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
-      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
-
       - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-12'
+        if: matrix.config.os == 'macos-13'
         run: |
+          brew update
           brew install docker
+          brew link --overwrite python@3.11
           colima start
           docker pull johnoel/admb-13.2:linux
 
@@ -243,8 +228,24 @@ jobs:
           chmod 777 SS330
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
-
           colima stop
+
+# brew install --head colima || true (after install docker)
+      # - name: Build stock synthesis for mac with admb docker image
+      #   if: matrix.config.os == 'macos-12'
+      #   run: |
+      #     brew install docker
+      #     colima start
+      #     docker pull johnoel/admb-13.2:linux
+
+      #     rm -rf SS330
+      #     rm -rf ss3_osx.tar
+      #     mkdir SS330
+      #     chmod 777 SS330
+      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
+      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
+
+      #     colima stop
 
       - name: Build stock synthesis for mac m2 with admb docker image
         if: matrix.config.os == 'macos-14'
@@ -263,13 +264,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,10 +218,8 @@ jobs:
         run: |
           brew update
           brew install docker
-          brew install colima
-          brew unlink colima
-          curl -L -o /usr/local/bin/colima https://github.com/abiosoft/colima/releases/download/v0.5.6/colima-Darwin-x86_64 && sudo chmod +x /usr/local/bin/colima
-          colima start --network-address
+          brew install colima || true
+          brew link --overwrite python@3.11
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,7 +218,7 @@ jobs:
         run: |
           brew update
           brew install --cask docker
-          brew install --HEAD lima
+          brew install --HEAD colima
           brew link --overwrite python@3.11
           colima start
           docker pull johnoel/admb-13.2:linux

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -20,7 +20,7 @@ jobs:
         config:
           - {os: windows-latest}
           - {os: macos-12}
-          - {os: macos-14}
+          - {os: macos-latest}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
     # was set to 15 and then 30 minutes previously, but compiling admb
@@ -111,7 +111,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -125,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -235,7 +235,7 @@ jobs:
         # compatible with x86_64 machines
 
       - name: Build stock synthesis for mac m2 with admb docker image
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-latest'
         run: |
           brew update
           brew install docker
@@ -251,13 +251,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -217,7 +217,8 @@ jobs:
         if: matrix.config.os == 'macos-13'
         run: |
           brew install docker
-          colima start
+          brew install --head colima
+          colima start --arch x86_64
           docker pull johnoel/admb:linux
 
           rm -rf SS330
@@ -227,7 +228,7 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
-          colima stop
+        # colima stop
 
       - name: Build stock synthesis for mac m2 with admb docker image
         if: matrix.config.os == 'macos-14'

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -220,7 +220,7 @@ jobs:
           brew install docker
           brew install --head colima || true
           brew link --overwrite python@3.11
-          colima start
+          colima start --arch x86_64
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,8 +218,8 @@ jobs:
         run: |
           brew install docker
           brew install --head colima
-          brew link docker
           brew services start colima
+          brew link docker
           docker pull johnoel/admb:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,7 +218,8 @@ jobs:
         run: |
           brew install docker
           brew install --head colima
-          colima start --arch x86_64
+          brew link docker
+          brew services start colima
           docker pull johnoel/admb:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -217,7 +217,8 @@ jobs:
         if: matrix.config.os == 'macos-13'
         run: |
           brew update
-          brew install docker
+          brew install --cask docker
+          brew install --HEAD lima
           brew link --overwrite python@3.11
           colima start
           docker pull johnoel/admb-13.2:linux

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -218,7 +218,7 @@ jobs:
         run: |
           brew update
           brew install docker
-          brew install --HEAD colima
+          brew install --HEAD colima || true
           colima start --arch x86_64
           docker pull johnoel/admb-13.2:linux
 

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -219,7 +219,7 @@ jobs:
           brew install docker
           brew install --head colima
           brew services start colima
-          brew link docker
+          docker context use colima
           docker pull johnoel/admb:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -20,7 +20,7 @@ jobs:
         config:
           - {os: windows-latest}
           - {os: macos-12}
-          - {os: macos-latest}
+          - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
     # was set to 15 and then 30 minutes previously, but compiling admb
@@ -111,7 +111,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -125,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -235,7 +235,7 @@ jobs:
         # compatible with x86_64 machines
 
       - name: Build stock synthesis for mac m2 with admb docker image
-        if: matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-14'
         run: |
           brew update
           brew install docker
@@ -251,13 +251,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         config:
           - {os: windows-latest}
-          - {os: macos-13}
+          - {os: macos-12}
           - {os: macos-14}
           - {os: ubuntu-latest}
     # Limit run time to 90 min to avoid wasting action minutes.
@@ -111,7 +111,7 @@ jobs:
 
       - name: Get the last tag on unix
         id: get-latest-tag-unix
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           git tag
           latest_tag=$(git describe --abbrev=0 --tags)
@@ -125,7 +125,7 @@ jobs:
 
       - name: pull the last tag value to use in the Rscript on unix
         id: get-version-unix
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14' || matrix.config.os == 'ubuntu-latest'
         run: |
           echo "${{ steps.get-latest-tag-unix.outputs.tag }}" > .github/last_tag.txt
           echo "${{ steps.get-latest-tag-unix.outputs.tag_commit }}" > .github/last_tag_commit.txt
@@ -213,27 +213,12 @@ jobs:
           mv SS330/ss3.exe SS330/ss3_win.exe
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
   
-      - name: Build stock synthesis for mac with admb docker image
-        if: matrix.config.os == 'macos-13'
-        run: |
-          brew update
-          brew install docker
-          brew install --HEAD colima || true
-          colima start --arch aarch64
-          docker pull johnoel/admb-13.2:linux
-
-          rm -rf SS330
-          rm -rf ss3_osx.tar
-          mkdir SS330
-          chmod 777 SS330
-          /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
-          /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
-          colima stop
-
       # - name: Build stock synthesis for mac with admb docker image
-      #   if: matrix.config.os == 'macos-12'
+      #   if: matrix.config.os == 'macos-13'
       #   run: |
+      #     brew update
       #     brew install docker
+      #     brew install --HEAD colima || true
       #     colima start
       #     docker pull johnoel/admb-13.2:linux
 
@@ -243,8 +228,23 @@ jobs:
       #     chmod 777 SS330
       #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
       #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
-
       #     colima stop
+
+      - name: Build stock synthesis for mac with admb docker image
+        if: matrix.config.os == 'macos-12'
+        run: |
+          brew install docker
+          colima start
+          docker pull johnoel/admb-13.2:linux
+
+          rm -rf SS330
+          rm -rf ss3_osx.tar
+          mkdir SS330
+          chmod 777 SS330
+          /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
+          /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
+
+          colima stop
 
       - name: Build stock synthesis for mac m2 with admb docker image
         if: matrix.config.os == 'macos-14'
@@ -263,13 +263,13 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
       - name: Verify binary on mac
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
         run: |
           shasum -a 256 SS330/ss3
           shasum -a 256 SS330/ss3_opt
           
       - name: Delete unneeded files and change exe names on mac
-        if: matrix.config.os == 'macos-13' || matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-12' || matrix.config.os == 'macos-14'
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss3_opt.tpl

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -220,7 +220,7 @@ jobs:
           brew install --cask docker
           brew install --HEAD colima
           brew link --overwrite python@3.11
-          colima start
+          colima start --arch aarch64
           docker pull johnoel/admb-13.2:linux
 
           rm -rf SS330

--- a/.github/workflows/build-ss3.yml
+++ b/.github/workflows/build-ss3.yml
@@ -212,23 +212,7 @@ jobs:
           mv Compile/ss3_opt.exe SS330/
           mv SS330/ss3.exe SS330/ss3_win.exe
           mv SS330/ss3_opt.exe SS330/ss3_opt_win.exe
-  
-      # - name: Build stock synthesis for mac with admb docker image
-      #   if: matrix.config.os == 'macos-13'
-      #   run: |
-      #     brew update
-      #     brew install docker
-      #     brew install --HEAD colima || true
-      #     colima start
-      #     docker pull johnoel/admb-13.2:linux
 
-      #     rm -rf SS330
-      #     rm -rf ss3_osx.tar
-      #     mkdir SS330
-      #     chmod 777 SS330
-      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330
-      #     /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
-      #     colima stop
 
       - name: Build stock synthesis for mac with admb docker image
         if: matrix.config.os == 'macos-12'
@@ -245,6 +229,10 @@ jobs:
           /bin/bash ./Make_SS_330_new.sh --admb docker -b SS330 -o
 
           colima stop
+
+        # Once macos-12 no longer is kept up by GitHub actions, we will have to 
+        # build from source the macos-13 and the macos-14 x86_64 images to make versions
+        # compatible with x86_64 machines
 
       - name: Build stock synthesis for mac m2 with admb docker image
         if: matrix.config.os == 'macos-14'

--- a/Compile/Make_SS_fast.bat
+++ b/Compile/Make_SS_fast.bat
@@ -41,9 +41,9 @@ for /f "tokens=*" %%i in ('where docker.exe 2^>^&1 ^| findstr "docker.exe"') do 
     set "ISWINDOWS10=found"
   )
   if defined ISWINDOWS10 (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2019-winlibs -f ss3_opt.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows10 -f ss3_opt.tpl
   ) else (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2022-winlibs -f ss3_opt.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows -f ss3_opt.tpl
   )
   goto CHECK
 )

--- a/Compile/Make_SS_fast.bat
+++ b/Compile/Make_SS_fast.bat
@@ -41,9 +41,9 @@ for /f "tokens=*" %%i in ('where docker.exe 2^>^&1 ^| findstr "docker.exe"') do 
     set "ISWINDOWS10=found"
   )
   if defined ISWINDOWS10 (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb:windows-ltsc2019-winlibs -f ss3_opt.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2019-winlibs -f ss3_opt.tpl
   ) else (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb:windows-ltsc2022-winlibs -f ss3_opt.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2022-winlibs -f ss3_opt.tpl
   )
   goto CHECK
 )

--- a/Compile/Make_SS_safe.bat
+++ b/Compile/Make_SS_safe.bat
@@ -44,9 +44,9 @@ for /f "tokens=*" %%i in ('where docker.exe 2^>^&1 ^| findstr "docker.exe"') do 
     set "ISWINDOWS10=found"
   )
   if defined ISWINDOWS10 (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb:windows-ltsc2019-winlibs ss3.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2019-winlibs ss3.tpl
   ) else (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb:windows-ltsc2022-winlibs ss3.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2022-winlibs ss3.tpl
   )
   goto CHECK
 )

--- a/Compile/Make_SS_safe.bat
+++ b/Compile/Make_SS_safe.bat
@@ -44,9 +44,9 @@ for /f "tokens=*" %%i in ('where docker.exe 2^>^&1 ^| findstr "docker.exe"') do 
     set "ISWINDOWS10=found"
   )
   if defined ISWINDOWS10 (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2019-winlibs ss3.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows10 ss3.tpl
   ) else (
-    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows-ltsc2022-winlibs ss3.tpl
+    docker run --rm --mount source=%CD%,destination=C:\compile,type=bind --workdir C:\\compile johnoel/admb-13.2:windows ss3.tpl
   )
   goto CHECK
 )

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -26,9 +26,9 @@ docker:
 ss3: ss3.tpl
 ifdef USE_DOCKER
   ifeq ($(OS),Windows_NT)
-	docker run --rm --volume $(CURDIR):C:\\workdir\\ss --workdir C:\\workdir\\ss johnoel/admb:windows-ltsc2022-winlibs ss3.tpl
+	docker run --rm --volume $(CURDIR):C:\\workdir\\ss --workdir C:\\workdir\\ss johnoel/admb-13.2:windows-ltsc2022-winlibs ss3.tpl
   else
-	docker run --rm --volume $(CURDIR):/workdir/ss:rw --workdir /workdir/ss johnoel/admb:linux ss3.tpl
+	docker run --rm --volume $(CURDIR):/workdir/ss:rw --workdir /workdir/ss johnoel/admb-13.2:linux ss3.tpl
   endif
 else
 	$(MY_ADMB_HOME)admb $(DEBUG)$(STATIC_BUILD) ss3.tpl
@@ -37,9 +37,9 @@ endif
 ss3_opt: ss3_opt.tpl
 ifdef USE_DOCKER
   ifeq ($(OS),Windows_NT)
-	docker run --rm --volume $(CURDIR):C:\\workdir\\ss_opt --workdir C:\\workdir\\ss_opt johnoel/admb:windows-ltsc2022-winlibs ss3_opt.tpl
+	docker run --rm --volume $(CURDIR):C:\\workdir\\ss_opt --workdir C:\\workdir\\ss_opt johnoel/admb-13.2:windows-ltsc2022-winlibs ss3_opt.tpl
   else
-	docker run --rm --volume $(CURDIR):/workdir/ss_opt:rw --workdir /workdir/ss_opt johnoel/admb:linux ss3_opt.tpl
+	docker run --rm --volume $(CURDIR):/workdir/ss_opt:rw --workdir /workdir/ss_opt johnoel/admb-13.2:linux ss3_opt.tpl
   endif
 else
 	$(MY_ADMB_HOME)admb -f $(DEBUG)$(STATIC_BUILD) ss3_opt.tpl

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,7 +37,7 @@ endif
 ss3_opt: ss3_opt.tpl
 ifdef USE_DOCKER
   ifeq ($(OS),Windows_NT)
-	docker run --rm --volume $(CURDIR):C:\\workdir\\ss_opt --workdir C:\\workdir\\ss_opt johnoel/admb-13.2:windows-ltsc2022-winlibs ss3_opt.tpl
+	docker run --rm --volume $(CURDIR):C:\\workdir\\ss_opt --workdir C:\\workdir\\ss_opt johnoel/admb-13.2:windows ss3_opt.tpl
   else
 	docker run --rm --volume $(CURDIR):/workdir/ss_opt:rw --workdir /workdir/ss_opt johnoel/admb-13.2:linux ss3_opt.tpl
   endif

--- a/Make_SS_330_new.sh
+++ b/Make_SS_330_new.sh
@@ -90,7 +90,7 @@ while [ "$1" != "" ]; do
                            ADMB_HOME=$1
                            export ADMB_HOME
                            PATH=$ADMB_HOME:$PATH
-			 fi
+			                   fi
                          ;;
          # output help - usage
         -h | --help )    Type=Default
@@ -188,9 +188,9 @@ if [[ "$ADMB_HOME" == "docker" ]] ; then
     fi
   else
     if [[ "$WARNINGS" == "on" ]] ; then
-      docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
+      docker run --platform linux/amd64 --env CXXFLAGS="-Wall -Wextra" --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
     else
-      docker run --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
+      docker run --platform linux/amd64 --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
     fi
   fi
 else

--- a/Make_SS_330_new.sh
+++ b/Make_SS_330_new.sh
@@ -175,15 +175,15 @@ if [[ "$ADMB_HOME" == "docker" ]] ; then
     fi
     if [[ "$WARNINGS" == "on" ]] ; then
       if [[ "$WINDOWS10" == "true" ]] ; then
-        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2019-winlibs $BUILD_TYPE.tpl
+        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows10 $BUILD_TYPE.tpl
       else
-        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2022-winlibs $BUILD_TYPE.tpl
+        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows $BUILD_TYPE.tpl
       fi 
     else
       if [[ "$WINDOWS10" == "true" ]] ; then
-        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2019-winlibs $BUILD_TYPE.tpl
+        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows10 $BUILD_TYPE.tpl
       else
-        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2022-winlibs $BUILD_TYPE.tpl
+        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows $BUILD_TYPE.tpl
       fi 
     fi
   else

--- a/Make_SS_330_new.sh
+++ b/Make_SS_330_new.sh
@@ -188,9 +188,9 @@ if [[ "$ADMB_HOME" == "docker" ]] ; then
     fi
   else
     if [[ "$WARNINGS" == "on" ]] ; then
-      docker run --platform linux/amd64 --env CXXFLAGS="-Wall -Wextra" --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
+      docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
     else
-      docker run --platform linux/amd64 --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
+      docker run --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
     fi
   fi
 else

--- a/Make_SS_330_new.sh
+++ b/Make_SS_330_new.sh
@@ -175,22 +175,22 @@ if [[ "$ADMB_HOME" == "docker" ]] ; then
     fi
     if [[ "$WARNINGS" == "on" ]] ; then
       if [[ "$WINDOWS10" == "true" ]] ; then
-        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb:windows-ltsc2019-winlibs $BUILD_TYPE.tpl
+        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2019-winlibs $BUILD_TYPE.tpl
       else
-        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb:windows-ltsc2022-winlibs $BUILD_TYPE.tpl
+        docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2022-winlibs $BUILD_TYPE.tpl
       fi 
     else
       if [[ "$WINDOWS10" == "true" ]] ; then
-        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb:windows-ltsc2019-winlibs $BUILD_TYPE.tpl
+        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2019-winlibs $BUILD_TYPE.tpl
       else
-        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb:windows-ltsc2022-winlibs $BUILD_TYPE.tpl
+        docker run --rm --mount source=`cygpath -w $PWD`\\$BUILD_DIR,destination=C:\\$BUILD_TYPE,mount=bind --workdir C:\\$BUILD_TYPE johnoel/admb-13.2:windows-ltsc2022-winlibs $BUILD_TYPE.tpl
       fi 
     fi
   else
     if [[ "$WARNINGS" == "on" ]] ; then
-      docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb:linux $BUILD_TYPE.tpl
+      docker run --env CXXFLAGS="-Wall -Wextra" --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
     else
-      docker run --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb:linux $BUILD_TYPE.tpl
+      docker run --rm --mount source=$PWD/$BUILD_DIR,destination=/$BUILD_TYPE,type=bind --workdir /$BUILD_TYPE johnoel/admb-13.2:linux $BUILD_TYPE.tpl
     fi
   fi
 else


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
The M2 chip macs that use arm64 (including macos-14) seem to behave a bit differently with the ss3 executables than the macs that use x86_64 architecture (macos-12 and before). Building the executable on a macos-14 runner fixed the issue that a user (Juan-Carlos) was having. I have now included building on a macos-14 machine in our GitHub actions. @iantaylor-NOAA noted that the macos-14 built executable does not work on older macs so building macos-12 is also necessary.

**In theory**, the [macos-latest image is supposed to be macos-14 right now](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) BUT a [recent run](https://github.com/nmfs-ost/ss3-test-models/actions/runs/8726783320/job/23942823321#step:8:14) testing updates I'm making to the r4ss get_ss3_exe() function to get the m2 exe showed that it had an x86_64 architecture OS (see R.version output) which is NOT what macos-14 had, so I'm not sure what's up there. When it does sort itself out, i'll switch where it says macos-14 to macos-latest. 

The macos-12 runner will eventually be discontinued. The macos-13 runner does not create an exe that will work when built with the workflow that uses the docker image (despite 2 days of trying) but it will create an exe that will work when built using the build-admb-and-ss3 workflow. 

I added a mac version that works for the arm64 architecture onto the v.3.30.21.1 release. 

Also officially updated to admb 13.2 version for github actions.

<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->

## What tests have been done? 
### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
- [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->
None.

## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
- [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
