### PR TITLE
add fatal error when using MCMC with recdev option 1

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -2168,6 +2168,17 @@
 
   init_int do_recdev  //  0=none; 1=devvector; 2=simple deviations; 3=dev from R0
 !!echoinput<<do_recdev<<" do_recdev"<<endl;
+  // check for use of devvector with MCMC
+ LOCAL_CALCS
+  // clang-format on
+  if (do_recdev == 1 & mcmcFlag == 1)
+  {
+    warnstream << "do_recdev option 1=devvector should not be used with MCMC, recommend option 2=simple deviations. For more detail see https://github.com/admb-project/admb/issues/107.";
+    write_message (FATAL, 0);
+  }
+  // clang-format off
+ END_CALCS
+
   init_int recdev_start;
 !!echoinput<<recdev_start<<" recdev_start"<<endl;
   init_int recdev_end;


### PR DESCRIPTION
This PR adds an error when you try to run MCMC with the setting do_recdev = 1. 
It was inspired by this discussion https://github.com/nmfs-ost/ss3-source-code/discussions/566 where a user noted getting bad results in the MCMC which I think are driven by the bug in ADMB described at https://github.com/admb-project/admb/issues/107.

## Concisely describe what has been changed/addressed in the pull request.
I thought of adding a warning instead of an error, but users may look at the warning file while running MLE estimates, decide that they can ignore the warnings, and not see that a new warning appears when running MCMC. I think the results of the MCMC are incorrect if using recdev option 1 so it's probably better to not allow them to get calculated in the first place.

## What tests have been done? 
I ran a model using `ss3 -mcmc 100` and confirmed that the command line and warning file includes the following message (feel free to suggest changes to it):
`
Warning 1 Fatal Error! do_recdev option 1=devvector should not be used with MCMC, recommend option 2=simple deviations. For more detail see https://github.com/admb-project/admb/issues/107.
`
- [x] No test files are required for this pull request. 

### What tests/review still need to be done?
None.

## Is there an input change for users to Stock Synthesis? 
- [x] No, there was no input change. 

## Additional context:
The build-ss3 github action is failing due to some issue with installing docker for the mac-os which seems unrelated to this change so probably doesn't need to hold up progress on this PR.