### PR TITLE
update discard warning plus one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Compile/ss3.log
 .Rhistory
 Compile/ssFileLabels.txt
 StockSynthesis.code-workspace
+Compile/Make_SS_warn.bat

--- a/Compile/Make_SS_warn.bat
+++ b/Compile/Make_SS_warn.bat
@@ -19,15 +19,15 @@ cd Compile
 
 if exist ss3.exe (
   if exist ss3_old.exe (
-    del ss3old.exe
+    del ss3_old.exe
   )
   ren ss3.exe ss3_old.exe
 )
 
 tpl2cpp ss3
 
-g++ -c -std=c++14 -O2 -D_FILE_OFFSET_BITS=64  -DUSE_ADMB_CONTRIBS -D_USE_MATH_DEFINES -I. -I"C:\ADMB-13.1\include" -I"C:\ADMB-13.1\include\contrib" -Wall -Wextra -o ss3.obj ss3.cpp
+g++ -c -std=c++17 -O2 -D_FILE_OFFSET_BITS=64  -DUSE_ADMB_CONTRIBS -D_USE_MATH_DEFINES -I. -I"C:\ADMB-13.2\include" -I"C:\ADMB-13.2\include\contrib" -Wall -Wextra -o ss3.obj ss3.cpp
 
-g++ -static -o ss3.exe ss3.obj "C:\ADMB-13.1\lib\libadmb-contrib-mingw64-g++8.a"
+g++ -static -o ss3.exe ss3.obj "C:\ADMB-13.2\lib\libadmb-contrib-mingw64-g++12.a"
 
 dir *.exe

--- a/SS_expval.tpl
+++ b/SS_expval.tpl
@@ -491,7 +491,7 @@ FUNCTION void Get_expected_values(const int y, const int t);
                       }
                       if (exp_disc(f, j) < 0.0)
                       {
-                        warnstream << f << " " << j << " " << exp_disc(f, j) << " catches " << catch_fleet(t, f);
+                        warnstream << "negative discard occurred for fleet: " << f << "; obs: " << j << "; usually ephemeral issue with bad iteration";
                         write_message (WARN, 0);
                       }
                     }

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -2171,7 +2171,7 @@
   // check for use of devvector with MCMC
  LOCAL_CALCS
   // clang-format on
-  if (do_recdev == 1 & mcmcFlag == 1)
+  if (do_recdev == 1 && mcmcFlag == 1)
   {
     warnstream << "do_recdev option 1=devvector should not be used with MCMC, recommend option 2=simple deviations. For more detail see https://github.com/admb-project/admb/issues/107.";
     write_message (FATAL, 0);


### PR DESCRIPTION
resolves #600 and updates fix for #590 

no additional testing need.  verified syntax of the updated label by viewing output in warning.sso:

Warning 6 : negative discard occurred for fleet: 1; obs: 28; usually ephemeral issue with bad iteration
