### PR TITLE
make column headings more consistent in data files 

### DIFF
--- a/SS_prelim.tpl
+++ b/SS_prelim.tpl
@@ -1424,7 +1424,7 @@
     bodywtout << "# fleet 0 contains begin season pop WT" << endl;
     bodywtout << "# fleet -1 contains mid season pop WT" << endl;
     bodywtout << "# fleet -2 contains maturity*fecundity" << endl;
-    bodywtout << "#Yr Seas Sex Bio_Pattern BirthSeas Fleet " << age_vector << endl;
+    bodywtout << "#_year seas sex bio_pattern birthseas fleet " << age_vector << endl;
   }
 
   if (Turn_off_phase < 0)

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -590,7 +590,7 @@
         t = styr + (y - styr) * nseas + s - 1;
         if (catch_record_count(f, t) > 1)
         {
-          warnstream << catch_record_count(f, t) << " catch records have been accumulated into yr, seas, fleet " << y << " " << s << " " << f << "; total catch= " << catch_ret_obs(f, t);
+          warnstream << catch_record_count(f, t) << " catch records have been accumulated into year, seas, fleet " << y << " " << s << " " << f << "; total catch= " << catch_ret_obs(f, t);
           write_message(WARN, 0);
         }
       }
@@ -982,7 +982,7 @@
   {
     echoinput << "#_discard_units (1=same_as_catchunits(bio/num);2=fraction; 3=numbers)" << endl;
     echoinput << "#_discard_error:  >0 for DF of T-dist(read CV below); 0 for normal with CV; -1 for normal with se; -2 for lognormal; -3 for trunc normal with CV" << endl;
-    echoinput << "#Fleet Units Err_Type" << endl;
+    echoinput << "#_fleet units errtype" << endl;
     echoinput << disc_units_rd << endl;
     for (j = 1; j <= Ndisc_fleets; j++)
     {
@@ -2131,7 +2131,7 @@
   }
 
   echoinput << "Overall_Compositions" << endl
-            << "Seas Fleet len_bins " << len_bins_dat << endl;
+            << "seas fleet len_bins " << len_bins_dat << endl;
   for (f = 1; f <= Nfleet; f++)
   {
     for (s = 1; s <= nseas; s++)
@@ -3592,7 +3592,7 @@
   ivector TG_endtime(1,N_TG2)
   ivector TG_use(1,N_TG2)  //  0/1 flag to indicate N recaptures >= TG_min_recap
   init_matrix TG_release(1,N_TG,1,8)
-  // TG area  year season tindex gender age N_released
+  // TG area year seas tfill sex age Nrelease
  LOCAL_CALCS
   // clang-format on
   TG_endtime(1) = 0;
@@ -3600,7 +3600,7 @@
   if (N_TG > 0)
   {
     echoinput << " Tag Releases " << endl
-              << "TG area year seas tindex gender age N_released " << endl
+              << "TG area year seas tfill sex age Nrelease " << endl
               << TG_release << endl;
     for (TG = 1; TG <= N_TG; TG++)
     {
@@ -3619,7 +3619,7 @@
 
 // SS_Label_Info_2.12.1 #Store recapture info by TG group and time to follow it as a cohort
   init_matrix TG_recap_data(1,N_TG_recap,1,5)
-  // TG, year, season, fleet, gender, Number
+  // TG, year, seas, fleet, sex, Nrecap
   3darray TG_recap_obs(1,N_TG2,0,TG_endtime,0,Nfleet);   //  no area index because each fleet is in just one area
  LOCAL_CALCS
   // clang-format on
@@ -3694,7 +3694,7 @@
     data_type = 8; // for morphcomp
 
     echoinput << " morph composition data" << endl
-              << "yr month fleet null Nsamp datavector" << endl;
+              << "year month fleet null Nsamp datavector" << endl;
     Morphcomp_nobs = 0;
     for (i = 1; i <= Morphcomp_nobs_rd; i++)
     {
@@ -3752,7 +3752,7 @@
   // clang-format on
   *(ad_comm::global_datafile) >> Do_SelexData;
   echoinput << "Do dataread for selectivity priors(0/1):  " << Do_SelexData << endl;
-  echoinput << "Yr  Seas Fleet  Age/Size  Bin  selex_prior  prior_sd" << endl;
+  echoinput << "year seas fleet age/size bin selex_prior prior_sd" << endl;
   echoinput << "feature not yet implemented" << endl;
   // clang-format off
  END_CALCS
@@ -4672,12 +4672,12 @@
     if (Fcast_InputCatch_Basis == -1)
     {
       j = 5;
-      echoinput << "# yr seas fleet catch basis" << endl;
+      echoinput << "# year seas fleet catch basis" << endl;
     }
     else
     {
       j = 4;
-      echoinput << "# yr seas fleet catch" << endl;
+      echoinput << "# year seas fleet catch" << endl;
     }
 
     ender = 0;
@@ -4974,7 +4974,7 @@
         else
         { //  no data
         }
-        echoinput << k << " N " << env_data_N(k) << " min-max yr " << env_data_minyr(k) << " " << env_data_maxyr(k) << " mean " << env_data_mean(k) << " stdev " << env_data_stdev(k) << " subtract mean " << env_data_do_mean(k) << " divide stddev " << env_data_do_stdev(k) << endl;
+        echoinput << k << " N " << env_data_N(k) << " min-max year " << env_data_minyr(k) << " " << env_data_maxyr(k) << " mean " << env_data_mean(k) << " stdev " << env_data_stdev(k) << " subtract mean " << env_data_do_mean(k) << " divide stddev " << env_data_do_stdev(k) << endl;
       }
     }
   }

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -2470,7 +2470,7 @@ FUNCTION void write_nucontrol()
   report4 << "#Pattern:_43; parm=2+special+2;  like 6, with 2 additional param for scaling (mean over bin range)" << endl;
   report4 << "#Pattern:_8;  parm=8; double_logistic with smooth transitions and constant above Linf option" << endl;
   report4 << "#Pattern:_9;  parm=6; simple 4-parm double logistic with starting length; parm 5 is first length; parm 6=1 does desc as offset" << endl;
-  report4 << "#Pattern:_21; parm=2+special; non-parm len selex, read as pairs of size, then selex" << endl;
+  report4 << "#Pattern:_21; parm=2*special; non-parm len selex, read as N break points, then N selex parameters" << endl;
   report4 << "#Pattern:_22; parm=4; double_normal as in CASAL" << endl;
   report4 << "#Pattern:_23; parm=6; double_normal where final value is directly equal to sp(6) so can be >1.0" << endl;
   report4 << "#Pattern:_24; parm=6; double_normal with sel(minL) and sel(maxL), using joiners" << endl;

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -111,7 +111,7 @@ FUNCTION void write_nudata()
     if (Nudat == 1) // report back the input data
     {
 
-      report1 << "#_Catch data: yr, seas, fleet, catch, catch_se" << endl;
+      report1 << "#_Catch data: year, seas, fleet, catch, catch_se" << endl;
       report1 << "#_catch_se:  standard error of log(catch)" << endl;
       report1 << "#_NOTE:  catch data is ignored for survey fleets" << endl;
       k = 0;
@@ -142,15 +142,15 @@ FUNCTION void write_nudata()
               << "#" << endl;
 
       report1 << "#_CPUE_and_surveyabundance_and_index_observations" << endl;
-      report1 << "#_Units: 0=numbers; 1=biomass; 2=F; 30=spawnbio; 31=exp(recdev); 36=recdev; 32=spawnbio*recdev; 33=recruitment; 34=depletion(&see Qsetup); 35=parm_dev(&see Qsetup)" << endl;
-      report1 << "#_Errtype:  -1=normal; 0=lognormal; 1=lognormal with bias correction; >1=df for T-dist" << endl;
-      report1 << "#_SD_Report: 0=not; 1=include survey expected value with se" << endl;
+      report1 << "#_units: 0=numbers; 1=biomass; 2=F; 30=spawnbio; 31=exp(recdev); 36=recdev; 32=spawnbio*recdev; 33=recruitment; 34=depletion(&see Qsetup); 35=parm_dev(&see Qsetup)" << endl;
+      report1 << "#_errtype:  -1=normal; 0=lognormal; 1=lognormal with bias correction; >1=df for T-dist" << endl;
+      report1 << "#_SD_report: 0=not; 1=include survey expected value with se" << endl;
       report1 << "#_note that link functions are specified in Q_setup section of control file" << endl;
       report1 << "#_dataunits = 36 and 35 should use Q_type 5 to provide offset parameter" <<endl;
-      report1 << "#_Fleet Units Errtype SD_Report" << endl;
+      report1 << "#_fleet units errtype SD_report" << endl;
       for (f = 1; f <= Nfleet; f++)
         report1 << f << " " << Svy_units(f) << " " << Svy_errtype(f) << " " << Svy_sdreport(f) << " # " << fleetname(f) << endl;
-      report1 << "#_yr month fleet obs stderr" << endl;
+      report1 << "#_year month fleet obs stderr" << endl;
 
       if (Svy_N > 0)
         for (f = 1; f <= Nfleet; f++)
@@ -169,13 +169,13 @@ FUNCTION void write_nudata()
       report1 << "#_discard_errtype:  >0 for DF of T-dist(read CV below); 0 for normal with CV; -1 for normal with se; -2 for lognormal; -3 for trunc normal with CV" << endl;
       report1 << "# note: only enter units and errtype for fleets with discard " << endl;
       report1 << "# note: discard data is the total for an entire season, so input of month here must be to a month in that season" << endl;
-      report1 << "#_Fleet units errtype" << endl;
+      report1 << "#_fleet units errtype" << endl;
       if (Ndisc_fleets > 0)
       {
         for (f = 1; f <= Nfleet; f++)
           if (disc_units(f) > 0)
             report1 << f << " " << disc_units(f) << " " << disc_errtype(f) << " # " << fleetname(f) << endl;
-        report1 << "#_yr month fleet obs stderr" << endl;
+        report1 << "#_year month fleet obs stderr" << endl;
         for (f = 1; f <= Nfleet; f++)
           for (i = 1; i <= disc_N_fleet(f); i++)
           {
@@ -196,7 +196,7 @@ FUNCTION void write_nudata()
         report1 << "#_COND_";
       report1 << DF_bodywt << " #_DF_for_meanbodysize_T-distribution_like" << endl;
       report1 << "# note:  type=1 for mean length; type=2 for mean body weight " << endl;
-      report1 << "#_yr month fleet part type obs stderr" << endl;
+      report1 << "#_year month fleet part type obs stderr" << endl;
       if (nobs_mnwt > 0)
       {
         for (i = 1; i <= nobs_mnwt; i++)
@@ -261,12 +261,12 @@ FUNCTION void write_nudata()
             report1 << comp_control_L[i] << endl;
         }
 
-        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sexxlength distribution" << endl;
+        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
         report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
         report1 << nlen_bin << " #_N_LengthBins; then enter lower edge of each length bin" << endl
                 << len_bins_dat << endl;
         //  report1<<nobsl_rd<<" #_N_Length_obs"<<endl;
-        report1 << "#_yr month fleet sex part Nsamp datavector(female-male)" << endl;
+        report1 << "#_year month fleet sex part Nsamp datavector(female-male)" << endl;
         if (nobsl_rd > 0)
         {
           for (i = 0; i <= nobsl_rd - 1; i++)
@@ -317,9 +317,9 @@ FUNCTION void write_nudata()
       if (n_abins <= 0)
         report1 << "# ";
       report1 << Lbin_method << " #_Lbin_method_for_Age_Data: 1=poplenbins; 2=datalenbins; 3=lengths" << endl;
-      report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sexxlength distribution" << endl;
+      report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
       report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
-      report1 << "#_yr month fleet sex part ageerr Lbin_lo Lbin_hi Nsamp datavector(female-male)" << endl;
+      report1 << "#_year month fleet sex part ageerr Lbin_lo Lbin_hi Nsamp datavector(female-male)" << endl;
       if (nobsa_rd > 0)
       {
         for (i = 0; i <= nobsa_rd - 1; i++)
@@ -339,10 +339,10 @@ FUNCTION void write_nudata()
               << use_meansizedata << " #_Use_MeanSize-at-Age_obs (0/1)" << endl;
       if (use_meansizedata > 0)
       {
-        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sexxlength distribution" << endl;
-        report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
+        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
+        report1 << "# partition codes:  0=combined; 1=discard; 2=retained" << endl;
         report1 << "# ageerr codes:  positive means mean length-at-age; negative means mean bodywt_at_age" << endl;
-        report1 << "#_yr month fleet sex part ageerr ignore datavector(female-male)" << endl;
+        report1 << "#_year month fleet sex part ageerr ignore datavector(female-male)" << endl;
         report1 << "#                                          samplesize(female-male)" << endl;
         if (nobs_ms_rd > 0)
         {
@@ -369,8 +369,8 @@ FUNCTION void write_nudata()
 
       report1 << "#" << endl
               << N_envvar << " #_N_environ_variables" << endl;
-      report1 << "# -2 in yr will subtract mean for that env_var; -1 will subtract mean and divide by stddev (e.g. Z-score)" << endl;
-      report1 << "#Yr Variable Value" << endl;
+      report1 << "# -2 in year will subtract mean for that env_var; -1 will subtract mean and divide by stddev (e.g. Z-score)" << endl;
+      report1 << "#_year variable value" << endl;
       if (N_envvar > 0)
       {
         for (i = 0; i <= N_envdata - 1; i++)
@@ -403,7 +403,7 @@ FUNCTION void write_nudata()
                 << "#Note: negative value for first bin makes it accumulate all smaller fish vs. truncate small fish" << endl;
         for (i = 1; i <= SzFreq_Nmeth; i++)
         { report1 << SzFreq_Omit_Small(i) * SzFreq_bins1(i, 1) << SzFreq_bins1(i)(2, SzFreq_Nbins(i)) << endl; }
-        report1 << "#_method year month fleet sex partition SampleSize <data> " << endl << SzFreq_obs1 << endl;
+        report1 << "#_method year month fleet sex part Nsamp <data> " << endl << SzFreq_obs1 << endl;
       }
 
       // begin tagging data section #1 (observed data)
@@ -427,11 +427,11 @@ FUNCTION void write_nudata()
 
         // tag releases
         report1 << "# Release data for each tag group.  Tags are considered to be released at the beginning of a season (period)" << endl;
-        report1 << "#<TG> area yr season <tfill> sex age Nrelease  (note that the TG and tfill values are placeholders and are replaced by program generated values)" << endl;
+        report1 << "#<TG> area year seas <tfill> sex age Nrelease  (note that the TG and tfill values are placeholders and are replaced by program generated values)" << endl;
         report1 << TG_release << endl;
 
         // tag recaptures
-        report1 << "#_TAG  Yr Season Fleet Nrecap" << endl;
+        report1 << "#_TG year seas fleet Nrecap" << endl;
         for (j = 1; j <= N_TG_recap; j++)
         {
           // fill in first 4 columns:
@@ -449,7 +449,7 @@ FUNCTION void write_nudata()
         report1 << Morphcomp_nobs_rd << "  #  Nobs" << endl;
         report1 << Morphcomp_nmorph << " # Nmorphs" << endl;
         report1 << Morphcomp_mincomp << " # add_to_comp" << endl;
-        report1 << "# yr, month, fleet, null, Nsamp, datavector_by_Nmorphs" << endl;
+        report1 << "#_year, month, fleet, null, Nsamp, datavector_by_Nmorphs" << endl;
         for (i = 1; i <= Morphcomp_nobs_rd; i++)
         {
           report1 << Morphcomp_obs_rd << endl;
@@ -458,12 +458,12 @@ FUNCTION void write_nudata()
       else
       {
         report1 << "#  Nobs, Nmorphs, mincomp" << endl;
-        report1 << "#  yr, seas, type, partition, Nsamp, datavector_by_Nmorphs" << endl;
+        report1 << "#_year, seas, type, partition, Nsamp, datavector_by_Nmorphs" << endl;
       }
 
       report1 << "#" << endl
               << Do_SelexData << "  #  Do dataread for selectivity priors(0/1)" << endl;
-      report1 << "# Yr, Seas, Fleet,  Age/Size,  Bin,  selex_prior,  prior_sd" << endl;
+      report1 << "#_year, seas, fleet, age/size, bin, selex_prior, prior_sd" << endl;
       report1 << "# feature not yet implemented" << endl;
 
       report1 << "#" << endl
@@ -474,8 +474,9 @@ FUNCTION void write_nudata()
     else if (Nudat == 2) // report expected value with no added error
     {
 
-      report1 << "#_catch:_columns_are_year,season,fleet,catch,catch_se" << endl;
-      report1 << "#_Catch data: yr, seas, fleet, catch, catch_se" << endl;
+      report1 << "#_Catch data: year, seas, fleet, catch, catch_se" << endl;
+      report1 << "#_catch_se:  standard error of log(catch)" << endl;
+      report1 << "#_NOTE:  catch data is ignored for survey fleets" << endl;
       k = 0;
       for (f = 1; f <= Nfleet; f++)
       {
@@ -511,12 +512,13 @@ FUNCTION void write_nudata()
       report1 << "-9999 0 0 0 0" << endl
               << "#" << endl;
 
-      report1 << "#" << endl
-              << " #_CPUE_and_surveyabundance_observations" << endl;
-      report1 << "#_Units:  0=numbers; 1=biomass; 2=F; 30=spawnbio; 31=recdev; 32=spawnbio*recdev; 33=recruitment; 34=depletion(&see Qsetup); 35=parm_dev(&see Qsetup)" << endl;
-      report1 << "#_Errtype:  -1=normal; 0=lognormal; 1=lognormal with bias correction; >1=df for T-dist" << endl;
-      report1 << "#_SD_Report: 0=not; 1=include survey expected value with se" << endl;
-      report1 << "#_Fleet Units Errtype SD_Report" << endl;
+      report1 << "#_CPUE_and_surveyabundance_and_index_observations" << endl;
+      report1 << "#_units: 0=numbers; 1=biomass; 2=F; 30=spawnbio; 31=exp(recdev); 36=recdev; 32=spawnbio*recdev; 33=recruitment; 34=depletion(&see Qsetup); 35=parm_dev(&see Qsetup)" << endl;
+      report1 << "#_errtype:  -1=normal; 0=lognormal; 1=lognormal with bias correction; >1=df for T-dist" << endl;
+      report1 << "#_SD_report: 0=not; 1=include survey expected value with se" << endl;
+      report1 << "#_note that link functions are specified in Q_setup section of control file" << endl;
+      report1 << "#_dataunits = 36 and 35 should use Q_type 5 to provide offset parameter" <<endl;
+      report1 << "#_fleet units errtype SD_report" << endl;
       for (f = 1; f <= Nfleet; f++)
         report1 << f << " " << Svy_units(f) << " " << Svy_errtype(f) << " " << Svy_sdreport(f) << " # " << fleetname(f) << endl;
       report1 << "#_year month index obs err" << endl;
@@ -549,13 +551,13 @@ FUNCTION void write_nudata()
       report1 << "#_discard_errtype:  >0 for DF of T-dist(read CV below); 0 for normal with CV; -1 for normal with se; -2 for lognormal; -3 for trunc normal with CV" << endl;
       report1 << "# note: only enter units and errtype for fleets with discard " << endl;
       report1 << "# note: discard data is the total for an entire season, so input of month here must be to a month in that season" << endl;
-      report1 << "#_Fleet units errtype" << endl;
+      report1 << "#_fleet units errtype" << endl;
       if (Ndisc_fleets > 0)
       {
         for (f = 1; f <= Nfleet; f++)
           if (disc_units(f) > 0)
             report1 << f << " " << disc_units(f) << " " << disc_errtype(f) << " # " << fleetname(f) << endl;
-        report1 << "#_yr month fleet obs stderr" << endl;
+        report1 << "#_year month fleet obs stderr" << endl;
         for (f = 1; f <= Nfleet; f++)
           if (disc_N_fleet(f) > 0)
             for (i = 1; i <= disc_N_fleet(f); i++)
@@ -581,7 +583,7 @@ FUNCTION void write_nudata()
         report1 << "#_COND_";
       report1 << DF_bodywt << " #_DF_for_meanbodysize_T-distribution_like" << endl;
       report1 << "# note:  type=1 for mean length; type=2 for mean body weight " << endl;
-      report1 << "#_yr month fleet part type obs stderr" << endl;
+      report1 << "#_year month fleet part type obs stderr" << endl;
       if (nobs_mnwt > 0)
       {
         for (i = 1; i <= nobs_mnwt; i++)
@@ -638,6 +640,9 @@ FUNCTION void write_nudata()
         else if (use_length_data == 2)
         {
           report1 << "#_Using new list format for composition controls" << endl;
+          report1 << "#_use negative fleet value to fill for all higher numbered fleets (recommended!)" << endl;
+          report1 << "#_must enter in fleet, partition order; but only need to enter for used combos" << endl;
+          report1 << "#_fleet = -9999 to terminate list" << endl;
           report1 << "#_fleet partition mintailcomp addtocomp combM+F CompressBins CompError ParmSelect minsamplesize" << endl;
           for (int i = 0; i <= comp_control_L_count; i++)
             report1 << comp_control_L[i] << endl;
@@ -648,7 +653,7 @@ FUNCTION void write_nudata()
         report1 << nlen_bin << " #_N_LengthBins" << endl
                 << len_bins_dat << endl;
         //  report1<<sum(Nobs_l)<<" #_N_Length_obs"<<endl;
-        report1 << "#_yr month fleet sex part Nsamp datavector(female-male)" << endl;
+        report1 << "#_year month fleet sex part Nsamp datavector(female-male)" << endl;
         for (f = 1; f <= Nfleet; f++)
         {
           if (Nobs_l(f) > 0)
@@ -708,7 +713,7 @@ FUNCTION void write_nudata()
       report1 << Lbin_method << " #_Lbin_method_for_Age_Data: 1=poplenbins; 2=datalenbins; 3=lengths" << endl;
       report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
       report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
-      report1 << "#_yr month fleet sex part ageerr Lbin_lo Lbin_hi Nsamp datavector(female-male)" << endl;
+      report1 << "#_year month fleet sex part ageerr Lbin_lo Lbin_hi Nsamp datavector(female-male)" << endl;
       if (Nobs_a_tot > 0)
         for (f = 1; f <= Nfleet; f++)
         {
@@ -737,10 +742,10 @@ FUNCTION void write_nudata()
               << use_meansizedata << " #_Use_MeanSize-at-Age_obs (0/1)" << endl;
       if (use_meansizedata > 0)
       {
-        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sexxlength distribution" << endl;
-        report1 << "# partition codes: 0=combined; 1=discard; 2=retained" << endl;
+        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
+        report1 << "# partition codes:  0=combined; 1=discard; 2=retained" << endl;
         report1 << "# ageerr codes:  positive means mean length-at-age; negative means mean bodywt_at_age" << endl;
-        report1 << "#_yr month fleet sex part ageerr ignore datavector(female-male)" << endl;
+        report1 << "#_year month fleet sex part ageerr ignore datavector(female-male)" << endl;
         report1 << "#                                          samplesize(female-male)" << endl;
         for (f = 1; f <= Nfleet; f++)
         {
@@ -775,8 +780,8 @@ FUNCTION void write_nudata()
 
       report1 << "#" << endl
               << N_envvar << " #_N_environ_variables" << endl;
-      report1 << "# -2 in yr will subtract mean for that env_var; -1 will subtract mean and divide by stddev (e.g. Z-score)" << endl;
-      report1 << "#Yr Variable Value" << endl;
+      report1 << "# -2 in year will subtract mean for that env_var; -1 will subtract mean and divide by stddev (e.g. Z-score)" << endl;
+      report1 << "#_year variable value" << endl;
       if (N_envvar > 0)
       {
         for (i = 0; i <= N_envdata - 1; i++)
@@ -809,7 +814,7 @@ FUNCTION void write_nudata()
                 << "#Note: negative value for first bin makes it accumulate all smaller fish vs. truncate small fish" << endl;
         for (i = 1; i <= SzFreq_Nmeth; i++)
         { report1 << SzFreq_Omit_Small(i) * SzFreq_bins1(i, 1) << SzFreq_bins1(i)(2, SzFreq_Nbins(i)) << endl; }
-        report1 << "#_method year month fleet sex partition SampleSize <data> " << endl;
+        report1 << "#_method year month fleet sex part Nsamp <data> " << endl;
         for (iobs = 1; iobs <= SzFreq_totobs; iobs++) {
           report1 << SzFreq_obs1(iobs)(1, 7) << " " << SzFreq_exp(iobs) << endl;
         }
@@ -828,13 +833,13 @@ FUNCTION void write_nudata()
 
         // tag releases
         report1 << "# Release data for each tag group.  Tags are considered to be released at the beginning of a season (period)" << endl;
-        report1 << "#<TG> area yr season <tfill> sex age Nrelease  (note that the TG and tfill values are placeholders and are replaced by program generated values)" << endl;
+        report1 << "#<TG> area year seas <tfill> sex age Nrelease  (note that the TG and tfill values are placeholders and are replaced by program generated values)" << endl;
         report1 << TG_release << endl;
 
         // tag recaptures
         report1 << "#_Note: Expected values for tag recaptures are reported only for the same combinations of" << endl;
         report1 << "#       group, year, area, and fleet that had observed recaptures. " << endl;
-        report1 << "#_TAG  Yr Season Fleet Nrecap" << endl;
+        report1 << "#_TG year seas fleet Nrecap" << endl;
         for (j = 1; j <= N_TG_recap; j++)
         {
           // fill in first 4 columns:
@@ -859,7 +864,7 @@ FUNCTION void write_nudata()
         report1 << Morphcomp_nobs << "  #  Nobs" << endl;
         report1 << Morphcomp_nmorph << " # Nmorphs" << endl;
         report1 << Morphcomp_mincomp << " # add_to_comp" << endl;
-        report1 << "# yr, month, fleet, null, Nsamp, datavector_by_Nmorphs" << endl;
+        report1 << "#_year, month, fleet, null, Nsamp, datavector_by_Nmorphs" << endl;
         for (i = 1; i <= Morphcomp_nobs; i++)
         {
           report1 << Morphcomp_obs(i)(1, 5) << " " << Morphcomp_exp(i) << endl;
@@ -868,12 +873,12 @@ FUNCTION void write_nudata()
       else
       {
         report1 << "#  Nobs, Nmorphs, mincomp" << endl;
-        report1 << "#  yr, seas, type, partition, Nsamp, datavector_by_Nmorphs" << endl;
+        report1 << "#_year, seas, type, partition, Nsamp, datavector_by_Nmorphs" << endl;
       }
 
       report1 << "#" << endl
               << Do_SelexData << "  #  Do dataread for selectivity priors(0/1)" << endl;
-      report1 << "# Yr, Seas, Fleet,  Age/Size,  Bin,  selex_prior,  prior_sd" << endl;
+      report1 << "#_year, seas, fleet, age/size, bin, selex_prior, prior_sd" << endl;
       report1 << "# feature not yet implemented" << endl;
 
       report1 << "#" << endl
@@ -884,9 +889,9 @@ FUNCTION void write_nudata()
     else //  create bootstrap data
     {
 
-      report1 << "#_catch_biomass(mtons):_columns_are_fisheries,year,season" << endl;
-      report1 << "#_catch:_columns_are_year,season,fleet,catch,catch_se" << endl;
-      report1 << "#_Catch data: yr, seas, fleet, catch, catch_se" << endl;
+      report1 << "#_Catch data: year, seas, fleet, catch, catch_se" << endl;
+      report1 << "#_catch_se:  standard error of log(catch)" << endl;
+      report1 << "#_NOTE:  catch data is ignored for survey fleets" << endl;
       k = 0;
       for (f = 1; f <= Nfleet; f++)
       {
@@ -924,11 +929,13 @@ FUNCTION void write_nudata()
       report1 << "-9999 0 0 0 0" << endl
               << "#" << endl;
 
-      report1 << " #_CPUE_and_surveyabundance_observations" << endl;
-      report1 << "#_Units:  0=numbers; 1=biomass; 2=F; 30=spawnbio; 31=recdev; 32=spawnbio*recdev; 33=recruitment; 34=depletion(&see Qsetup); 35=parm_dev(&see Qsetup)" << endl;
-      report1 << "#_Errtype:  -1=normal; 0=lognormal; 1=lognormal with bias correction; >1=df for T-dist" << endl;
-      report1 << "#_SD_Report: 0=not; 1=include survey expected value with se" << endl;
-      report1 << "#_Fleet Units Errtype SD_Report" << endl;
+      report1 << "#_CPUE_and_surveyabundance_and_index_observations" << endl;
+      report1 << "#_units: 0=numbers; 1=biomass; 2=F; 30=spawnbio; 31=exp(recdev); 36=recdev; 32=spawnbio*recdev; 33=recruitment; 34=depletion(&see Qsetup); 35=parm_dev(&see Qsetup)" << endl;
+      report1 << "#_errtype:  -1=normal; 0=lognormal; 1=lognormal with bias correction; >1=df for T-dist" << endl;
+      report1 << "#_SD_report: 0=not; 1=include survey expected value with se" << endl;
+      report1 << "#_note that link functions are specified in Q_setup section of control file" << endl;
+      report1 << "#_dataunits = 36 and 35 should use Q_type 5 to provide offset parameter" <<endl;
+      report1 << "#_fleet units errtype SD_report" << endl;
       for (f = 1; f <= Nfleet; f++)
         report1 << f << " " << Svy_units(f) << " " << Svy_errtype(f) << " " << Svy_sdreport(f) << " # " << fleetname(f) << endl;
       report1 << "#_year month index obs err" << endl;
@@ -972,7 +979,7 @@ FUNCTION void write_nudata()
         for (f = 1; f <= Nfleet; f++)
           if (disc_units(f) > 0)
             report1 << f << " " << disc_units(f) << " " << disc_errtype(f) << " # " << fleetname(f) << endl;
-        report1 << "#_yr month fleet obs stderr" << endl;
+        report1 << "#_year month fleet obs stderr" << endl;
         for (f = 1; f <= Nfleet; f++)
           for (i = 1; i <= disc_N_fleet(f); i++)
           {
@@ -1024,7 +1031,7 @@ FUNCTION void write_nudata()
         report1 << "#_COND_";
       report1 << DF_bodywt << " #_DF_for_meanbodysize_T-distribution_like" << endl;
       report1 << "# note:  type=1 for mean length; type=2 for mean body weight " << endl;
-      report1 << "#_yr month fleet part type obs stderr" << endl;
+      report1 << "#_year month fleet part type obs stderr" << endl;
 
       // NOTE, the se stored in mnwtdata(7,i) was adjusted in prelim calc to include the input var_adjustment
       //  so var_adjust is subtracted here when the observation is written
@@ -1089,15 +1096,19 @@ FUNCTION void write_nudata()
         else if (use_length_data == 2)
         {
           report1 << "#_Using new list format for composition controls" << endl;
+          report1 << "#_use negative fleet value to fill for all higher numbered fleets (recommended!)" << endl;
+          report1 << "#_must enter in fleet, partition order; but only need to enter for used combos" << endl;
+          report1 << "#_fleet = -9999 to terminate list" << endl;
           report1 << "#_fleet partition mintailcomp addtocomp combM+F CompressBins CompError ParmSelect minsamplesize" << endl;
           for (int i = 0; i <= comp_control_L_count; i++)
             report1 << comp_control_L[i] << endl;
         }
+
+        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
+        report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
         report1 << nlen_bin << " #_N_LengthBins" << endl
                 << len_bins_dat << endl;
-        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sexxlength distribution" << endl;
-        report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
-        report1 << "#_yr month fleet sex part Nsamp datavector(female-male)" << endl;
+        report1 << "#_year month fleet sex part Nsamp datavector(female-male)" << endl;
         for (f = 1; f <= Nfleet; f++)
         {
           if (Nobs_l(f) > 0)
@@ -1193,7 +1204,7 @@ FUNCTION void write_nudata()
       report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
       report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
 
-      report1 << "#_yr month fleet sex part ageerr Lbin_lo Lbin_hi Nsamp datavector(female-male)" << endl;
+      report1 << "#_year month fleet sex part ageerr Lbin_lo Lbin_hi Nsamp datavector(female-male)" << endl;
       if (Nobs_a_tot > 0)
         for (f = 1; f <= Nfleet; f++)
         {
@@ -1254,10 +1265,10 @@ FUNCTION void write_nudata()
               << use_meansizedata << " #_Use_MeanSize-at-Age_obs (0/1)" << endl;
       if (use_meansizedata > 0)
       {
-        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sexxlength distribution" << endl;
-        report1 << "# partition codes:  (0=combined; 1=discard; 2=retained" << endl;
+        report1 << "# sex codes:  0=combined; 1=use female only; 2=use male only; 3=use both as joint sex*length distribution" << endl;
+        report1 << "# partition codes:  0=combined; 1=discard; 2=retained" << endl;
         report1 << "# ageerr codes:  positive means mean length-at-age; negative means mean bodywt_at_age" << endl;
-        report1 << "#_yr month fleet sex part ageerr ignore datavector(female-male)" << endl;
+        report1 << "#_year month fleet sex part ageerr ignore datavector(female-male)" << endl;
         report1 << "#                                          samplesize(female-male)" << endl;
         for (f = 1; f <= Nfleet; f++)
         {
@@ -1292,8 +1303,8 @@ FUNCTION void write_nudata()
 
       report1 << "#" << endl
               << N_envvar << " #_N_environ_variables" << endl;
-      report1 << "# -2 in yr will subtract mean for that env_var; -1 will subtract mean and divide by stddev (e.g. Z-score)" << endl;
-      report1 << "#Yr Variable Value" << endl;
+      report1 << "# -2 in year will subtract mean for that env_var; -1 will subtract mean and divide by stddev (e.g. Z-score)" << endl;
+      report1 << "#_year variable value" << endl;
       if (N_envvar > 0)
       {
         for (i = 0; i <= N_envdata - 1; i++)
@@ -1326,7 +1337,7 @@ FUNCTION void write_nudata()
                 << "#Note: negative value for first bin makes it accumulate all smaller fish vs. truncate small fish" << endl;
         for (i = 1; i <= SzFreq_Nmeth; i++)
         { report1 << SzFreq_Omit_Small(i) * SzFreq_bins1(i, 1) << SzFreq_bins1(i)(2, SzFreq_Nbins(i)) << endl; }
-        report1 << "#_method year month fleet sex partition SampleSize <data> " << endl;
+        report1 << "#_method year month fleet sex part Nsamp <data> " << endl;
         j = 2 * max(SzFreq_Nbins);
         dvector temp_probs3(1, j);
         dvector SzFreq_newdat(1, j);
@@ -1437,13 +1448,13 @@ FUNCTION void write_nudata()
 
         // tag releases
         report1 << "# Release data for each tag group.  Tags are considered to be released at the beginning of a season (period)" << endl;
-        report1 << "#<TG> area yr season <tfill> sex age Nrelease  (note that the TG and tfill values are placeholders and are replaced by program generated values)" << endl;
+        report1 << "#<TG> area year seas <tfill> sex age Nrelease  (note that the TG and tfill values are placeholders and are replaced by program generated values)" << endl;
         report1 << TG_release << endl;
 
         // tag recaptures
         report1 << "#_Note: Bootstrap values for tag recaptures are produced only for the same combinations of" << endl;
         report1 << "#       group, year, area, and fleet that had observed recaptures. " << endl;
-        report1 << "#_TAG  Yr Season Fleet Nrecap" << endl;
+        report1 << "#_TG year seas fleet Nrecap" << endl;
         for (j = 1; j <= N_TG_recap_gen; j++)
         {
           report1 << TG_recap_gen(j) << endl;
@@ -1459,7 +1470,7 @@ FUNCTION void write_nudata()
         report1 << Morphcomp_nobs << "  #  Nobs" << endl;
         report1 << Morphcomp_nmorph << " # Nmorphs" << endl;
         report1 << Morphcomp_mincomp << " # add_to_comp" << endl;
-        report1 << "#  yr, month, fleet, null, Nsamp, datavector_by_Nmorphs  (no error added!!!)" << endl;
+        report1 << "#_year, month, fleet, null, Nsamp, datavector_by_Nmorphs (no error added!!!)" << endl;
         for (i = 1; i <= Morphcomp_nobs; i++)
         {
           report1 << Morphcomp_obs(i)(1, 5) << " " << Morphcomp_exp(i) << endl;
@@ -1468,13 +1479,13 @@ FUNCTION void write_nudata()
       else
       {
         report1 << "#  Nobs, Nmorphs, mincomp" << endl;
-        report1 << "#  yr, seas, type, partition, Nsamp, datavector_by_Nmorphs" << endl;
+        report1 << "#_year, seas, type, partition, Nsamp, datavector_by_Nmorphs" << endl;
       }
 
       report1 << "#" << endl
               << Do_SelexData << "  #  Do dataread for selectivity priors(0/1)" << endl;
-      report1 << " # Yr, Seas, Fleet,  Age/Size,  Bin,  selex_prior,  prior_sd" << endl;
-      report1 << " # feature not yet implemented" << endl;
+      report1 << "#_year, seas, fleet, age/size, bin, selex_prior, prior_sd" << endl;
+      report1 << "# feature not yet implemented" << endl;
 
       report1 << "#" << endl
               << "999" << endl
@@ -1528,8 +1539,8 @@ FUNCTION void write_nucontrol()
           << burn_intvl << " # MCeval burn interval" << endl;
   NuStart << thin_intvl << " # MCeval thin interval" << endl;
   NuStart << jitter << " # jitter initial parm value by this fraction" << endl;
-  NuStart << STD_Yr_min_rd << " # min yr for sdreport outputs (-1 for styr); #_" << STD_Yr_min << endl;
-  NuStart << STD_Yr_max_rd << " # max yr for sdreport outputs (-1 for endyr+1; -2 for endyr+Nforecastyrs); #_" << STD_Yr_max << endl;
+  NuStart << STD_Yr_min_rd << " # min year for sdreport outputs (-1 for styr); #_" << STD_Yr_min << endl;
+  NuStart << STD_Yr_max_rd << " # max year for sdreport outputs (-1 for endyr+1; -2 for endyr+Nforecastyrs); #_" << STD_Yr_max << endl;
   NuStart << N_STD_Yr_RD << " # N individual STD years " << endl;
   NuStart << "#COND: vector of year values if N>0" << endl
           << STD_Yr_RD << endl;
@@ -1537,7 +1548,7 @@ FUNCTION void write_nucontrol()
   NuStart << final_conv << " # final convergence criteria (e.g. 1.0e-04) " << endl;
   NuStart << retro_yr - endyr << " # retrospective year relative to end year (e.g. -4)" << endl;
   NuStart << Smry_Age << " # min age for calc of summary biomass" << endl;
-  NuStart << depletion_basis_rd << " # Depletion basis:  denom is: 0=skip; 1=X*SPBvirgin; 2=X*SPBmsy; 3=X*SPB_styr; 4=X*SPB_endyr; 5=X*dyn_Bzero;  values>=11 invoke N multiyr with 10s & 100s digit; append .1 to invoke log(ratio); e.g. 122.1 produces log(12 yr trailing average of B/Bmsy)" << endl;
+  NuStart << depletion_basis_rd << " # Depletion basis:  denom is: 0=skip; 1=X*SPBvirgin; 2=X*SPBmsy; 3=X*SPB_styr; 4=X*SPB_endyr; 5=X*dyn_Bzero;  values>=11 invoke N multiyr with 10s & 100s digit; append .1 to invoke log(ratio); e.g. 122.1 produces log(12 year trailing average of B/Bmsy)" << endl;
   NuStart << depletion_level << " # Fraction (X) for Depletion denominator (e.g. 0.4)" << endl;
   NuStart << SPR_reporting << " # SPR_report_basis:  0=skip; 1=(1-SPR)/(1-SPR_tgt); 2=(1-SPR)/(1-SPR_MSY); 3=(1-SPR)/(1-SPR_Btarget); 4=rawSPR" << endl;
   NuStart << F_reporting << " # F_std_reporting_units: 0=skip; 1=exploitation(Bio); 2=exploitation(Num); 3=sum(Apical_F's); 4=mean F for range of ages (numbers weighted); 5=unweighted mean F for range of ages" << endl;
@@ -1670,7 +1681,7 @@ FUNCTION void write_nucontrol()
   NuFore << Fcast_Catch_Basis << " # basis for fcast catch tuning and for fcast catch caps and allocation  (2=deadbio; 3=retainbio; 5=deadnum; 6=retainnum); NOTE: same units for all fleets" << endl;
 
   NuFore << "# Conditional input if relative F choice = 2" << endl;
-  NuFore << "# enter list of:  season,  fleet, relF; if used, terminate with season=-9999" << endl;
+  NuFore << "# enter list of:  season, fleet, relF; if used, terminate with season=-9999" << endl;
   {
     for (s = 1; s <= nseas; s++)
       for (f = 1; f <= Nfleet; f++)
@@ -1743,7 +1754,7 @@ FUNCTION void write_nucontrol()
   NuFore << Fcast_InputCatch_Basis << " # basis for input Fcast catch: -1=read basis with each obs; 2=dead catch; 3=retained catch; 99=input apical_F; NOTE: bio vs num based on fleet's catchunits" << endl;
 
   NuFore << "#enter list of Fcast catches or Fa; terminate with line having year=-9999" << endl;
-  NuFore << "#_Yr Seas Fleet Catch(or_F)";
+  NuFore << "#_year seas fleet catch(or_F)";
   if (Fcast_InputCatch_Basis == -1)
     NuFore << " Basis ";
   NuFore << endl;
@@ -2203,7 +2214,7 @@ FUNCTION void write_nucontrol()
   if (recdev_read > 0)
   {
     report4 << "# Specified recr devs to read" << endl;
-    report4 << "#_Yr Input_value # Final_value" << endl;
+    report4 << "#_year Input_value # Final_value" << endl;
     for (j = 1; j <= recdev_read; j++)
     {
       y = recdev_input(j, 1);
@@ -2221,7 +2232,7 @@ FUNCTION void write_nucontrol()
   else
   {
     report4 << "# read specified recr devs" << endl;
-    report4 << "#_Yr Input_value" << endl;
+    report4 << "#_year Input_value" << endl;
   }
   report4 << "#" << endl;
   report4 << "# all recruitment deviations" << endl
@@ -2303,7 +2314,7 @@ FUNCTION void write_nucontrol()
     report4 << F_Method_PH(1) << " # start phase for parms (does hybrid in early phases)" << endl;
     report4 << F_detail << " # N detailed inputs to read" << endl;
     report4 << "# detailed setup for F_Method=2; -Yr to fill remaining years; -999 for phase or se ignores keeps default for those fields " << endl;
-    report4 << "#Fleet Yr Seas F_value se phase" << endl;
+    report4 << "#_fleet year seas F_value se phase" << endl;
     if (F_detail > 0)
       report4 << F_setup2 << endl;
   }
@@ -2324,14 +2335,14 @@ FUNCTION void write_nucontrol()
     }
     if (F_detail <=0 )
     {report4 << -9999 << " 1 1 # end of list" << endl <<
-       "#F_detail template: Fleet Yr Seas F_value catch_se phase" << endl; }
+       "#F_detail template: fleet year seas F_value catch_se phase" << endl; }
     else
     {report4 << -9998 << " 1 1 # end of list, trigger reading F_detail" << endl; }
     report4 << F_Tune << " #_number of loops for hybrid tuning; 4 precise; 3 faster; 2 enough if switching to parms is enabled" << endl;
     if (F_detail > 0)
     {
       report4 << " # F_detail:  List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run" << endl;
-      report4 << "#Fleet Yr Seas F_value catch_se phase" << endl;
+      report4 << "#fleet year seas F_value catch_se phase" << endl;
       report4 << F_setup2 << endl;
       report4 << "-9999 1 1 1 1 1  # end of F_detail: time-specific F inputs " << endl;
     }
@@ -2363,7 +2374,7 @@ FUNCTION void write_nucontrol()
 
   report4 << "#" << endl
           << "# F rates by fleet x season" << endl;
-  report4 << "# Yr: ";
+  report4 << "#_year: ";
   for (y = styr; y <= YrMax; y++)
     for (s = 1; s <= nseas; s++)
     {
@@ -2701,7 +2712,7 @@ FUNCTION void write_nucontrol()
   report4 << " #_5=mult_by_agecomp_N" << endl;
   report4 << " #_6=mult_by_size-at-age_N" << endl;
   report4 << " #_7=mult_by_generalized_sizecomp" << endl;
-  report4 << "#_Factor  Fleet  Value" << endl;
+  report4 << "#_factor  fleet  value" << endl;
   {
     if (var_adjust_data.size() > 0)
       for (f = 1; f <= Do_Var_adjust; f++)


### PR DESCRIPTION
Initially posting as a draft pull request to foster discussion before marking ready for review.

## Concisely describe what has been changed/addressed in the pull request.
- Aligns a few inconsistencies in the column headers written to data_echo.ss_new (and expected and boostrap data files).
  - more consistent use of lowercase headers
  - "season" to "seas" (which is more common)
  - "partition" to "part"  (which is more common)
  - "SampleSize" to "Nsamp" (which is more common)
  - make things match better across the three types of data ss_new files as well as echoinput (in part because this helped confirm that the changes above were made throughout)
- Change "yr" to "year" as suggested in this comment and the one below from @kellijohnson-NOAA https://github.com/r4ss/r4ss/issues/512#issuecomment-1438728972.
- Changes are in parallel with changes in the r4ss function to read the data files initiated thanks to @e-perl-NOAA in https://github.com/r4ss/r4ss/pull/945.

## What tests have been done? 
None so far. The changes should only be to comments, not numerical values, so I don't think additional testing of SS3 itself is needed.

## What tests/review still need to be done?
The read/write of data files by r4ss should be tested against these changes along with the status-quo output.

## Is there an input change for users to Stock Synthesis? 
[x] No, there was no input change.