### PR TITLE
separate annual timeseries from spr series; improve mean_age reporting

### DIFF
--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -50,7 +50,7 @@ jobs:
         run: Rscript -e 'install.packages(c("remotes","parallely", "furrr", "future"))'
 
       - name: Install r4ss
-        run: Rscript -e 'remotes::install_github("r4ss/r4ss", ref = "spr_split_tables")'
+        run: Rscript -e 'remotes::install_github("r4ss/r4ss")'
 
       # - name: Get admb and put in path, linux
       #   run: |

--- a/.github/workflows/test-r4ss-with-ss3.yml
+++ b/.github/workflows/test-r4ss-with-ss3.yml
@@ -50,7 +50,7 @@ jobs:
         run: Rscript -e 'install.packages(c("remotes","parallely", "furrr", "future"))'
 
       - name: Install r4ss
-        run: Rscript -e 'remotes::install_github("r4ss/r4ss")'
+        run: Rscript -e 'remotes::install_github("r4ss/r4ss", ref = "spr_split_tables")'
 
       # - name: Get admb and put in path, linux
       #   run: |

--- a/SS_benchfore.tpl
+++ b/SS_benchfore.tpl
@@ -2534,6 +2534,7 @@ FUNCTION void Get_Forecast()
             SSB_pop_gp(y).initialize();
             SSB_B_yr(y).initialize();
             SSB_N_yr(y).initialize();
+            Smry_Table(y, 15) = 0.0;
             for (p = 1; p <= pop; p++)
             {
               for (g = 1; g <= gmorph; g++)
@@ -2545,6 +2546,7 @@ FUNCTION void Get_Forecast()
                   SSB_pop_gp(y, p, GP4(g)) += fracfemale_mult * fec(g) * natage(t, p, g); // accumulates SSB by area and by growthpattern
                   SSB_B_yr(y) += fracfemale_mult * make_mature_bio(GP4(g)) * natage(t, p, g);
                   SSB_N_yr(y) += fracfemale_mult * make_mature_numbers(GP4(g)) * natage(t, p, g);
+                  Smry_Table(y, 15) += fracfemale_mult * natage(t, p, g) * elem_prod(fec(g), r_ages);  //  for mean age of female spawners = GenTime
                 }
             }
             SSB_current = sum(SSB_pop_gp(y));
@@ -3173,6 +3175,7 @@ FUNCTION void Get_Forecast()
             SSB_pop_gp(y).initialize();
             SSB_B_yr(y).initialize();
             SSB_N_yr(y).initialize();
+            Smry_Table(y, 15) = 0.0;
             for (p = 1; p <= pop; p++)
             {
               for (g = 1; g <= gmorph; g++)
@@ -3181,6 +3184,7 @@ FUNCTION void Get_Forecast()
                   SSB_pop_gp(y, p, GP4(g)) += fracfemale_mult * fec(g) * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas)); // accumulates SSB by area and by growthpattern
                   SSB_B_yr(y) += fracfemale_mult * make_mature_bio(GP4(g)) * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas));
                   SSB_N_yr(y) += fracfemale_mult * make_mature_numbers(GP4(g)) * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas));
+                  Smry_Table(y, 15) += fracfemale_mult * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas)) * elem_prod(fec(g), r_ages);  //  for mean age of female spawners = GenTime
                 }
             }
             SSB_current = sum(SSB_pop_gp(y));
@@ -3651,11 +3655,6 @@ FUNCTION void Get_Forecast()
         Smry_Table(y, 10) = smrybio;
         Smry_Table(y, 12) = SSB_equil;
         Smry_Table(y, 14) = YPR_dead;
-        for (g = 1; g <= gmorph; g++)
-        {
-          Smry_Table(y, 20 + g) = (cumF(g));
-          Smry_Table(y, 20 + gmorph + g) = (maxF(g));
-        }
       }
     } //  end year loop
   } //  end Fcast_Loop1  for the different stages of the forecast

--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -417,8 +417,6 @@ PARAMETER_SECTION
    number alpha;
    number beta;
    number GenTime;
-   vector cumF(1,gmorph);
-   vector maxF(1,gmorph);
    number Yield;
    number Adj4010;
 
@@ -599,11 +597,10 @@ PARAMETER_SECTION
   number equ_M_std
   
 !!//  SS_Label_Info_5.1.8 #Create matrix called smry to store derived quantities of interest
-  matrix Smry_Table(styr-3,YrMax,1,20+2*gmorph);
+  matrix Smry_Table(styr-3,YrMax,1,17);
   // 1=totbio, 2=smrybio, 3=smrynum, 4=enc_catch, 5=dead_catch, 6=ret_catch, 7=spbio, 8=recruit,
   // 9=equ_totbio, 10=equ_smrybio, 11=equ_SSB_virgin, 12=equ_S1, 13=Gentime, 14=YPR, 15=meanage_spawners, 16=meanage_smrynums, 17=meanage_catch
-  // 18, 19, 20  not used
-  // 21+cumF-bymorph, maxF-by morph
+ 
 
   matrix env_data(styr-1,YrMax,-4,N_envvar)
   matrix TG_save(1,N_TG,1,3+TG_endtime)

--- a/SS_popdyn.tpl
+++ b/SS_popdyn.tpl
@@ -960,6 +960,7 @@ FUNCTION void get_time_series()
         SSB_pop_gp(y).initialize();
         SSB_B_yr(y).initialize();
         SSB_N_yr(y).initialize();
+        Smry_Table(y, 15) = 0.0;
         for (p = 1; p <= pop; p++)
         {
           for (g = 1; g <= gmorph; g++)
@@ -968,6 +969,7 @@ FUNCTION void get_time_series()
               SSB_pop_gp(y, p, GP4(g)) += fracfemale_mult * fec(g) * natage(t, p, g); // accumulates SSB by area and by growthpattern
               SSB_B_yr(y) += fracfemale_mult * make_mature_bio(GP4(g)) * natage(t, p, g);
               SSB_N_yr(y) += fracfemale_mult * make_mature_numbers(GP4(g)) * natage(t, p, g);
+              Smry_Table(y, 15) += fracfemale_mult * natage(t, p, g) * elem_prod(fec(g), r_ages);  //  for mean age of female spawners = GenTime
               //            SSB_pop_gp(y,p,GP4(g)) += fec(g)*natage(t,p,g);   // accumulates SSB by area and by growthpattern
               //            SSB_B_yr(y) += make_mature_bio(GP4(g))*natage(t,p,g);
               //            SSB_N_yr(y) += make_mature_numbers(GP4(g))*natage(t,p,g);
@@ -1422,6 +1424,7 @@ FUNCTION void get_time_series()
         SSB_pop_gp(y).initialize();
         SSB_B_yr(y).initialize();
         SSB_N_yr(y).initialize();
+        Smry_Table(y, 15) = 0.0;
         for (p = 1; p <= pop; p++)
         {
           for (g = 1; g <= gmorph; g++)
@@ -1430,11 +1433,11 @@ FUNCTION void get_time_series()
               SSB_pop_gp(y, p, GP4(g)) += fracfemale_mult * fec(g) * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas)); // accumulates SSB by area and by growthpattern
               SSB_B_yr(y) += fracfemale_mult * make_mature_bio(GP4(g)) * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas));
               SSB_N_yr(y) += fracfemale_mult * make_mature_numbers(GP4(g)) * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas));
+              Smry_Table(y, 15) += fracfemale_mult * elem_prod(natage(t, p, g), mfexp(-Z_rate(t, p, g) * spawn_time_seas)) * elem_prod(fec(g), r_ages);  //  for mean age of female spawners = GenTime
             }
         }
         SSB_current = sum(SSB_pop_gp(y));
         SSB_yr(y) = SSB_current;
-
         if (Hermaphro_Option != 0) // get male biomass
         {
           MaleSPB(y).initialize();
@@ -1771,11 +1774,6 @@ FUNCTION void get_time_series()
       Smry_Table(y, 10) = (smrybio);
       Smry_Table(y, 12) = (SSB_equil);
       Smry_Table(y, 14) = (YPR_dead);
-      for (g = 1; g <= gmorph; g++)
-      {
-        Smry_Table(y, 20 + g) = (cumF(g));
-        Smry_Table(y, 20 + gmorph + g) = (maxF(g));
-      }
     }
   } //close year loop
 
@@ -1815,8 +1813,6 @@ FUNCTION void Do_Equil_Calc(const prevariable& equ_Recr)
   t_base = styr + (eq_yr - styr) * nseas - 1;
   GenTime.initialize();
   Equ_penalty.initialize();
-  cumF.initialize();
-  maxF.initialize();
   SSB_equil_pop_gp.initialize();
   if (Hermaphro_Option != 0)
     MaleSSB_equil_pop_gp.initialize();
@@ -1831,6 +1827,7 @@ FUNCTION void Do_Equil_Calc(const prevariable& equ_Recr)
   smrybio = 0.0;
   smryage = 0.0;
   smrynum = 0.0;
+  GenTime = 0.0;
 
   // first seed the recruits; seems redundant
   for (g = 1; g <= gmorph; g++)
@@ -1923,12 +1920,6 @@ FUNCTION void Do_Equil_Calc(const prevariable& equ_Recr)
                 {
                   equ_Z(s, p, g, a1) = -(log((Nsurvive + 1.0e-13) / (N_beg + 1.0e-10))) / seasdur(s);
                   Fishery_Survival = equ_Z(s, p, g, a1) - natM(t, p, GP3(g), a1);
-                  if (a >= Smry_Age)
-                  {
-                    cumF(g) += Fishery_Survival * seasdur(s);
-                    if (Fishery_Survival > maxF(g))
-                      maxF(g) = Fishery_Survival;
-                  }
                 }
 
               } // end Pope's approx
@@ -1944,14 +1935,6 @@ FUNCTION void Do_Equil_Calc(const prevariable& equ_Recr)
                     {
                       f = fish_fleet_area(p, ff);
                       equ_Z(s, p, g, a1) += sel_dead_num(s, f, g, a1) * Hrate(f, t);
-                    }
-                    if (save_for_report > 0)
-                    {
-                      temp = equ_Z(s, p, g, a1) - natM(t, p, GP3(g), a1);
-                      if (a >= Smry_Age && a <= nages)
-                        cumF(g) += temp * seasdur(s);
-                      if (temp > maxF(g))
-                        maxF(g) = temp;
                     }
                   }
                 }
@@ -2261,7 +2244,6 @@ FUNCTION void Do_Equil_Calc(const prevariable& equ_Recr)
   SSB_equil = sum(SSB_equil_pop_gp);
   GenTime /= SSB_equil;
   smryage /= smrynum;
-  cumF /= (r_ages(nages) - r_ages(Smry_Age) + 1.);
   if (Hermaphro_maleSPB > 0.0) // add MaleSPB to female SSB
   {
     SSB_equil += Hermaphro_maleSPB * sum(MaleSSB_equil_pop_gp);

--- a/SS_proced.tpl
+++ b/SS_proced.tpl
@@ -15,6 +15,7 @@ PROCEDURE_SECTION
   Mgmt_quant.initialize();
   Extra_Std.initialize();
   CrashPen.initialize();
+  Smry_Table.initialize();
   niter++;
   if (mceval_phase())
     mceval_counter++; // increment the counter

--- a/SS_readstarter.tpl
+++ b/SS_readstarter.tpl
@@ -319,6 +319,8 @@
   pick_report_use += "N";
   pick_report_name += "wtatage.ss_new report:60";
   pick_report_use += "N";
+  pick_report_name += "ANNUAL_TIME_SERIES report:61";
+  pick_report_use += "N";
 
   // check command line inputs
 
@@ -494,10 +496,11 @@
     pick_report_use(14) = "Y";
     pick_report_use(15) = "Y";
     pick_report_use(16) = "Y";
+    pick_report_use(61) = "Y";
   }
   else if (rd_background == 2) // brief, no growth or length
   {
-    for (k = 1; k <= 60; k++)
+    for (k = 1; k <= 61; k++)
     {
       pick_report_use(k) = "Y"; // start with all on
     }
@@ -533,7 +536,7 @@
   }
   else // all on
   {
-    for (k = 1; k <= 60; k++)
+    for (k = 1; k <= 61; k++)
     {
       pick_report_use(k) = "Y";
     }

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -164,7 +164,7 @@ FUNCTION void write_bigoutput()
 
   SS2out << endl
          << "#_KeyWords_of_tables_available_in_report_sso" << endl;
-  SS2out << "#NOTE: table_number_is_order_in_which_tables_are_output" << endl;
+  SS2out << "#_NOTE: table_number_is_order_in_which_tables_are_output" << endl;
   SS2out << "#_List_Tables_related_to_basic_input_pre-processing_and_output" << endl;
   k = 1;
   SS2out << pick_report_use(k) << " " << pick_report_name(k) << endl; // DEFINITIONS"
@@ -217,6 +217,8 @@ FUNCTION void write_bigoutput()
   SS2out << pick_report_use(k) << " " << pick_report_name(k) << endl; // SPR_series (equilibrium_SPR_and_YPR_calculations_for_each_year)
   k = 16;
   SS2out << pick_report_use(k) << " " << pick_report_name(k) << endl; // TIME_SERIES
+  k = 61;
+  SS2out << pick_report_use(k) << " " << pick_report_name(k) << endl; // ANNUAL_TIME_SERIES
 
   SS2out << endl
          << "# List_Tables_related_to_fit_to_data" << endl;
@@ -1100,7 +1102,7 @@ FUNCTION void write_bigoutput()
   {
     SS2out << endl
            << pick_report_name(12) << endl;
-    SS2out << "#NOTE: rows_are_population_length_bins;_columns_are_recipient_size_bins_according_to_the_specified_method" << endl;
+    SS2out << "#_NOTE: rows_are_population_length_bins;_columns_are_recipient_size_bins_according_to_the_specified_method" << endl;
     for (SzFreqMethod = 1; SzFreqMethod <= SzFreq_Nmeth; SzFreqMethod++)
     {
       SS2out << SzFreqMethod << " gp seas len mid-len ";
@@ -1565,13 +1567,13 @@ FUNCTION void write_bigoutput()
   {
     SS2out << endl
            << pick_report_name(17) << endl;
-    SS2out << "#_NOTE:_reports_per_recruit_quantities_using_current_year_biology;_using_same_equil_calc_routine_used_for_reference_points" << endl;
-    SS2out << "#_NOTE:_current_year_biology_is_current_at-age_biology_from_time_series;_not_recalc_biology_from_current_growth_parameters" << endl;
-    SS2out << "#_NOTE:_uses_R0= " << Recr_virgin << endl;
-    SS2out << "#_NOTE:_Y/R_unit_is_Dead_Biomass" << endl;
-    SS2out << "#_NOTE:_gentime_is_mean_age_of_female_spawners_weighted_by_reproductive_value-at-age_(fec(g))" << endl;
+    SS2out << "#_NOTE: reports_per_recruit_quantities_using_current_year_biology;_using_same_equil_calc_routine_used_for_reference_points" << endl;
+    SS2out << "#_NOTE: current_year_biology_is_current_at-age_biology_from_time_series;_not_recalc_biology_from_current_growth_parameters" << endl;
+    SS2out << "#_NOTE: uses_R0= " << Recr_virgin << endl;
+    SS2out << "#_NOTE: YPR_unit_is_Dead_Biomass" << endl;
+    SS2out << "#_NOTE: gentime_is_mean_age_of_female_spawners_weighted_by_reproductive_value-at-age_(fec(g))" << endl;
 
-    SS2out << "Yr Era Bio_all_eq Bio_Smry_eq SSB_unfished_eq SSBfished_eq SSBfished/R SPR  Y/R GenTime" << endl;
+    SS2out << "Yr Era Bio_all_eq Bio_Smry_eq SSB_unfished_eq SSBfished_eq SSBfished/R SPR  YPR GenTime" << endl;
 
     for (y = styr; y <= YrMax; y++)
     {
@@ -1587,15 +1589,23 @@ FUNCTION void write_bigoutput()
       SS2out << (Smry_Table(y, 14) / Recr_virgin) << " " << Smry_Table(y, 13) << endl;
     } // end year loop
     // end SPR time series
+  }
 
-    SS2out << "#" << endl << "ANNUAL_TIME_SERIES report:17a" << endl;
+  if (pick_report_use(61) == "Y")  // ANNUAL_TIME_SERIES report:61
+  {
+    SS2out << endl
+           << pick_report_name(61) << endl;
     SS2out << "#_NOTE: MnAgeSmry_is_numbers_weighted_meanage_at_and_above_smryage:_" << Smry_Age << endl;
     SS2out << "#_NOTE:_mean_age_of_catch_is_numbers-weighted_and_based_on_catage_which_is_the_dead_catch_and_comes_from:_sel_dead_num_=_sel_*_(retain_+_(1-retain)*discmort)" << endl;
     SS2out << "#_NOTE: Depletion_basis: " << depletion_basis << " # " << depletion_basis_label << endl;
     SS2out << "#_NOTE: F_report_basis: " << F_reporting << " # " << F_report_label << endl;
     SS2out << "#_NOTE: SPR_report_basis: " << SPR_reporting << " # " << SPR_report_label << endl;
+    SS2out << "#_NOTE: tot_exploit:_is_dead_catch_B/bio_smry" << endl;
+    SS2out << "#_NOTE: sum_fleet_F:_is_simple_sum_of_full_Fs_among_all_fleets_ignoring_seasonal_and_area_modifiers" << endl;
+    SS2out << "#_NOTE: suffix:_an_emphasizes_that_quantity_is_annual_and_all_areas" << endl;
+
     SS2out << "year Era Bio_all_an Bio_Smry_an Num_Smry_an SSB recruits sel_catch_B_an dead_catch_B_an retain_catch_B_an sel_catch_N_an dead_catch_N_an retain_catch_N_an" <<
-              " dead_catch_B/bio_smry sum_fleet_F F=Z-M M mn_age_SSB mn_age_smry mn_age_catch  SPR_std Depletion_std F_std" << endl;
+              " tot_exploit sum_fleet_F F=Z-M M mn_age_SSB mn_age_smry mn_age_catch SPR_std Depletion_std F_std" << endl;
   // 1=totbio, 2=smrybio, 3=smrynum, 4=enc_catch, 5=dead_catch, 6=ret_catch, 7=spbio, 8=recruit,
   // 9=equ_totbio, 10=equ_smrybio, 11=equ_SSB_virgin, 12=equ_S1, 13=Gentime, 14=YPR, 15=meanage_spawners, 16=meanage_smrynums, 17=meanage_catch
   
@@ -3728,7 +3738,7 @@ FUNCTION void write_bigoutput()
            << pick_report_name(48) << endl;
     if (WTage_rd > 0)
       SS2out << " as read from wtatage.ss";
-    SS2out << "#NOTE: yr=_" << styr - 3 << "_stores_values_for_benchmark" << endl;
+    SS2out << "#_NOTE: yr=_" << styr - 3 << "_stores_values_for_benchmark" << endl;
     SS2out << "Morph Yr Seas" << age_vector << endl;
     for (g = 1; g <= gmorph; g++)
       if (use_morph(g) > 0)
@@ -4842,7 +4852,7 @@ FUNCTION void SPR_profile()
   if (Do_Benchmark == 3)
     SS2out << "#value 8 is F_Blimit: " << Btgt_Fmult2 << endl;
   SS2out << "#Profile 7 increases from Fmsy to Fcrash" << endl;
-  SS2out << "#NOTE: meanage_of_catch_is_for_total_catch_of_fleet_type==1_or_bycatch_fleets_with_scaled_Hrate" << endl;
+  SS2out << "#_NOTE: meanage_of_catch_is_for_total_catch_of_fleet_type==1_or_bycatch_fleets_with_scaled_Hrate" << endl;
   // end SPR/YPR_Profile
   return;
   }

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -873,8 +873,8 @@ FUNCTION void write_bigoutput()
   {
     SS2out << endl
            << pick_report_name(6) << endl;
-    SS2out << "SPR_report_basis: " << SPR_report_label << endl;
-    SS2out << "F_report_basis: " << F_report_label << endl;
+    SS2out << "SPR_std_report_basis: " << SPR_report_label << endl;
+    SS2out << "F_std_report_basis: " << F_report_label << endl;
     SS2out << "B_ratio_denominator: " << depletion_basis_label << endl;
     NP = deriv_start;
     active_count = deriv_covar_start;
@@ -1185,8 +1185,8 @@ FUNCTION void write_bigoutput()
   {
     SS2out << endl
            << pick_report_name(14) << endl;
-    SS2out << "Info: Displays.various.annual.F.statistics.and.displays.apical.F.for.each.fleet.by.season" << endl;
-    SS2out << "Info: F_Method:=" << F_Method;
+    SS2out << "NOTE: Displays.various.annual.F.statistics.and.displays.apical.F.for.each.fleet.by.season" << endl;
+    SS2out << "NOTE: F_Method:=" << F_Method;
     if (F_Method == 1)
     {
       SS2out << ";.Pope's_approx,.fleet.F.is.mid-season.exploitation.fraction ";
@@ -1196,16 +1196,16 @@ FUNCTION void write_bigoutput()
       SS2out << ";.Continuous_F;.fleet.F.will.be.multiplied.by.season.duration.when.it.is.used.and.in.the.F_std.calculation";
     }
     SS2out << endl
-           << "Info: Displayed.fleet-specific.F.values.are.the.F.for.ages.with.compound.age-length-sex.selectivity=1.0" << endl;
-    SS2out << "Info: F_std_basis:." << F_report_label << endl;
+           << "NOTE: Displayed.fleet-specific.F.values.are.the.F.for.ages.with.compound.age-length-sex.selectivity=1.0" << endl;
+    SS2out << "NOTE: F_std_basis: " << F_report_label << endl;
     SS2out << "F_std averaged over N years: " << F_std_multi << endl;
     if (F_reporting >= 4)
     {
-      SS2out << "Info: Annual_F.shown.here.is.done.by.the.Z-M.method.for.ages:." << F_reporting_ages(1) << "-" << F_reporting_ages(2) << endl;
+      SS2out << "NOTE: Annual_F.shown.here.is.done.by.the.Z-M.method.for.ages:." << F_reporting_ages(1) << "-" << F_reporting_ages(2) << endl;
     }
     else
     {
-      SS2out << "Info: Annual_F.shown.here.is.done.by.the.Z-M.method.for.nages/2=" << nages / 2 << endl;
+      SS2out << "NOTE: Annual_F.shown.here.is.done.by.the.Z-M.method.for.nages/2=" << nages / 2 << endl;
     }
     SS2out << "#" << endl;
     SS2out << "Yr Seas Seas_dur F_std annual_F annual_M ";
@@ -1598,8 +1598,8 @@ FUNCTION void write_bigoutput()
     SS2out << "#_NOTE: MnAgeSmry_is_numbers_weighted_meanage_at_and_above_smryage:_" << Smry_Age << endl;
     SS2out << "#_NOTE:_mean_age_of_catch_is_numbers-weighted_and_based_on_catage_which_is_the_dead_catch_and_comes_from:_sel_dead_num_=_sel_*_(retain_+_(1-retain)*discmort)" << endl;
     SS2out << "#_NOTE: Depletion_basis: " << depletion_basis << " # " << depletion_basis_label << endl;
-    SS2out << "#_NOTE: F_report_basis: " << F_reporting << " # " << F_report_label << endl;
-    SS2out << "#_NOTE: SPR_report_basis: " << SPR_reporting << " # " << SPR_report_label << endl;
+    SS2out << "#_NOTE: F_std_report_basis: " << F_reporting << " # " << F_report_label << endl;
+    SS2out << "#_NOTE: SPR_std_report_basis: " << SPR_reporting << " # " << SPR_report_label << endl;
     SS2out << "#_NOTE: tot_exploit:_is_dead_catch_B/bio_smry" << endl;
     SS2out << "#_NOTE: sum_fleet_F:_is_simple_sum_of_full_Fs_among_all_fleets_ignoring_seasonal_and_area_modifiers" << endl;
     SS2out << "#_NOTE: suffix:_an_emphasizes_that_quantity_is_annual_and_all_areas" << endl;
@@ -4612,7 +4612,7 @@ FUNCTION void SPR_profile()
       }
   }
 
-  SS2out << "SPRloop Iter Bycatch Fmult F_report SPR YPR_dead YPR_dead*Recr YPR_ret*Recr Revenue Cost Profit SSB Recruits SSB/Bzero Tot_Catch ";
+  SS2out << "SPRloop Iter Bycatch Fmult F_std SPR YPR_dead YPR_dead*Recr YPR_ret*Recr Revenue Cost Profit SSB Recruits SSB/Bzero Tot_Catch ";
   for (f = 1; f <= Nfleet; f++)
   {
     if (fleet_type(f) <= 2)


### PR DESCRIPTION
resolves #607 

Information is in the issue.
The annual_time_series table has been separated from the SPR_series table such that only per-recruit values are in the SPR table.  
update and check the mean age values
add more notes on each table

Testing can be done with any model.

needs work with r4ss
