### PR TITLE
Fix typo in warning.sso output file

### DIFF
--- a/SS_global.tpl
+++ b/SS_global.tpl
@@ -1189,7 +1189,7 @@ FINAL_SECTION
     //  SS_Label_Info_12.4.7 #Finish up with final writes to warning.sso
     if (N_changed_lambdas > 0)
     {
-      warnstream << "Reminder: Number of lamdas !=0.0 and !=1.0:  " << N_changed_lambdas;
+      warnstream << "Reminder: Number of lambdas !=0.0 and !=1.0:  " << N_changed_lambdas;
 	  write_message(WARN, 0);
     }
 


### PR DESCRIPTION
Hi, I'm running an SS3 model and notice that the warning.sso output file says "Number of lamdas !=0.0 and !=1.0:  8".

This pull request changes the warning message to say "lambdas" instead of "lamdas".