### PR TITLE
improve Fdetail info in ssnew for Fmethod 4

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -2663,7 +2663,7 @@
         echoinput << "hybrid tuning loops as read: " << F_Tune << endl;
         if (ender == -9998)  // flag to trigger reading F_detail for f x t specific F values
         {
-          echoinput << "# now read List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run" << endl;
+          echoinput << "# now read List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run; end that list with -1 for fleet" << endl;
           echoinput << "#Fleet Yr Seas F_value catch_se phase" << endl;
 
           dvector tempvec(1, 6);

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -2327,7 +2327,8 @@ FUNCTION void write_nucontrol()
     report4 << "# Read list of fleets that do F as parameter; unlisted fleets stay hybrid, bycatch fleets must be included with start_PH=1, high F fleets should switch early" << endl;
     report4 << "# (A) fleet;" << endl <<"# (B) F_starting_value (ignored if start_PH=1 or reading from ss3.par);" <<
     endl << "# (C) start_PH for fleet's Fparms (99 to stay in hybrid, <0 to stay at starting value)" << endl << 
-    "# Terminate list with -9999 for fleet (use -9998 to read fleet-time specific F values after reading N hybrid tune loops)" << endl;
+    "# Terminate list with -9999 for fleet" << endl <<
+    "# or terminate with -9998 to invoke reading fleet-time specific F values after first reading N hybrid tune loops)" << endl;
     report4 << "# (A) (B) (C)" << endl;
     for (unsigned j = 1; j <= F_Method_4_input.size() - 2; j++)
     {
@@ -2337,14 +2338,14 @@ FUNCTION void write_nucontrol()
     {report4 << -9999 << " 1 1 # end of list" << endl <<
        "#F_detail template: fleet year seas F_value catch_se phase" << endl; }
     else
-    {report4 << -9998 << " 1 1 # end of list, trigger reading F_detail" << endl; }
+    {report4 << -9998 << " 1 1 # end of list, triggers reading F_detail" << endl; }
     report4 << F_Tune << " #_number of loops for hybrid tuning; 4 precise; 3 faster; 2 enough if switching to parms is enabled" << endl;
     if (F_detail > 0)
     {
-      report4 << " # F_detail:  List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run" << endl;
+      report4 << "# F_detail:  List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run" << endl;
       report4 << "#fleet year seas F_value catch_se phase" << endl;
       report4 << F_setup2 << endl;
-      report4 << "-9999 1 1 1 1 1  # end of F_detail: time-specific F inputs " << endl;
+      report4 << "-9999 1 1 1 1 1  # end of F_detail" << endl;
     }
   }
 


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
Information on use of F_detail needed improvement for F method 4.

<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves issue #
no linked issue
## What tests have been done? 
The revised control.ss_new now looks like:
```
4 # F_Method:  1=Pope midseason rate; 2=F as parameter; 3=F as hybrid; 4=fleet-specific parm/hybrid (#4 is superset of #2 and #3 and is recommended)
2.95 # max F (methods 2-4) or harvest fraction (method 1)
 # Read list of fleets that do F as parameter; unlisted fleets stay hybrid, bycatch fleets must be included with start_PH=1, high F fleets should switch early
 # (A) fleet;
 # (B) F_starting_value (ignored if start_PH=1 or reading from ss3.par);
 # (C) start_PH for fleet's Fparms (99 to stay in hybrid, <0 to stay at starting value)
 # Terminate list with -9999 for fleet
 # or terminate with -9998 to invoke reading fleet-time specific F values after first reading N hybrid tune loops)
 # (A) (B) (C)
 1 0.05 99 # FISHERY
-9998 1 1 # end of list, triggers reading F_detail
4 #_number of loops for hybrid tuning; 4 precise; 3 faster; 2 enough if switching to parms is enabled
# F_detail:  List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run
#fleet year seas F_value catch_se phase
 1 2000 1 0.05 0.01 1
 1 1999 1 0.04 0.01 1
-9999 1 1 1 1 1  # end of F_detail
#
```
and the info in echoinput is:
```
4 F_Method as read
2.95 max_harvest_rate 
read list of fleet ID, starting F, and phase to transition to parameters
 1 0.05 99
 -9998 1 1
now read N tuning loops while in hybrid phases (2 is OK if switching to parm later, 3 OK, 4 more precise with many fleets)
hybrid tuning loops as read: 4
# now read List of fleet-time specific F related values to read; enter -Yr to fill remaining years&seasons; -999 for phase or catch_se keeps base value for the run; end that list with -1 for fleet
#Fleet Yr Seas F_value catch_se phase
 1 2000 1 0.05 0.01 1
 1 1999 1 0.04 0.01 1
 -1 1 1 1 1 1
 detailed F_setups 
 1 2000 1 0.05 0.01 1
 1 1999 1 0.04 0.01 1
```
### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<!-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->

- [ ] update Manual accordingly

## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<!-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
