### PR TITLE
age-based calc of sel_dead_num and bio is repaired

### DIFF
--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -1973,10 +1973,11 @@ FUNCTION void Make_FishSelex()
           }
           case 2:
           {
+            // details of retention and mortality already taken into account with calc of discmort2_a
             sel_ret_bio(s, f, g) = elem_prod(sel_bio(s, f, g), retain_a(y, f, gg)); //  retained wt-at-age
             sel_ret_num(s, f, g) = elem_prod(sel_num(s, f, g), retain_a(y, f, gg)); //  retained numbers
-            sel_dead_bio(s, f, g) = elem_prod(sel_ret_bio(s, f, g), discmort_a(y, f, gg)); //  dead wt
-            sel_dead_num(s, f, g) = elem_prod(sel_ret_num(s, f, g), discmort_a(y, f, gg)); //  dead numbers
+            sel_dead_bio(s, f, g) = elem_prod(Wt_Age_t(tz, f, g), discmort2_a(y, f, gg)); //  dead wt
+            sel_dead_num(s, f, g) = discmort2_a(y, f, gg); //  dead numbers
             break;
           }
           case 3: //  all selected fish are dead
@@ -1987,6 +1988,11 @@ FUNCTION void Make_FishSelex()
             sel_dead_num(s, f, g) = sel_num(s, f, g); //  dead numbers
             break;
           }
+        }
+        if (docheckup == 1 && y == styr)
+        {
+          echoinput << " sel_ret_bio " << sel_ret_bio(s, f, g) << endl
+                    << " sel_dead_bio " << sel_dead_bio(s, f, g) << endl;
         }
       }
 


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->


<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves issue #662

## What tests have been done? 
when use age-based selectivity, retention and discard mortality, the results now appear correct with the sel_dead values intermediate between the sel and the sel*ret values
### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->

## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
