### PR TITLE
revise warn msg for retention with EWAA

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -3563,8 +3563,8 @@
     {
       if (WTage_rd > 0)
       {
-        warnstream << "Retention functions not implemented fully when reading empirical wt-at-age ";
-        write_message (WARN, 0);
+        warnstream << "Length-based retention will use the same empirical wtatage for discard and retained fish for fleet: " << f;
+        write_message (NOTE, 0);
       }
       Do_Retain(f) = 1;
       if (fleet_type(f) == 2 && seltype(f, 2) != 3)
@@ -3880,8 +3880,8 @@
       Do_Retain(f1) = 2;
       if (WTage_rd > 0)
       {
-        warnstream << "Retention functions not implemented fully when reading empirical wt-at-age ";
-        write_message (WARN, 0);
+        warnstream << "Age-based retention will use the same empirical wtatage for discarded and retained fish for fleet: " << f;
+        write_message (NOTE, 0);
       }
       if (seltype(f1, 2) > 0)
       {


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
no Issue created.  Simple revision of language to clarify how retention functions work with EWAA,  New NOTE msg states that when using EWAA, the same body wt is used for discarded and retained fish for both length-retention and age-retention.  i.e.
```
    if (seltype(f, 2) >= 1)
    {
      if (WTage_rd > 0)
      {
        warnstream << "Length-based retention will use the same empirical wtatage for discard and retained fish for fleet: " << f;
        write_message (NOTE, 0);
```


<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves issue #

## What tests have been done? 
none needed
### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->
none
## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
