### PR TITLE
Apply a steeper join function for the piecewise-linear harvest control rule

### DIFF
--- a/SS_benchfore.tpl
+++ b/SS_benchfore.tpl
@@ -2777,8 +2777,8 @@ FUNCTION void Get_Forecast()
           else if (ABC_Loop == 2 && s == 1) // Calc the buffer in season 1, will use last year's spawnbio if multiseas and spawnseas !=1
           {
 
-            join1 = 1. / (1. + mfexp(10. * (SSB_current - H4010_bot * HCR_anchor)));
-            join2 = 1. / (1. + mfexp(10. * (SSB_current - H4010_top * HCR_anchor)));
+            join1 = 1. / (1. + mfexp(1000. * (SSB_current - H4010_bot * HCR_anchor)));
+            join2 = 1. / (1. + mfexp(1000. * (SSB_current - H4010_top * HCR_anchor)));
 
             switch (HarvestPolicy)
             {

--- a/SS_benchfore.tpl
+++ b/SS_benchfore.tpl
@@ -2777,8 +2777,8 @@ FUNCTION void Get_Forecast()
           else if (ABC_Loop == 2 && s == 1) // Calc the buffer in season 1, will use last year's spawnbio if multiseas and spawnseas !=1
           {
 
-            join1 = 1. / (1. + mfexp(1000. * (SSB_current - H4010_bot * HCR_anchor)));
-            join2 = 1. / (1. + mfexp(1000. * (SSB_current - H4010_top * HCR_anchor)));
+            join1 = 1. / (1. + mfexp(100. * (SSB_current - H4010_bot * HCR_anchor)));
+            join2 = 1. / (1. + mfexp(100. * (SSB_current - H4010_top * HCR_anchor)));
 
             switch (HarvestPolicy)
             {


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.
The join function creating differentiable values for the piecewise-linear harvest control rule was leading to OFL*buffer != ACL, with differences in projected catch limits of 1-2 tons. 

Catch limits are the subject of lots of interest, it's important to have the calculations match exactly. This may only impact petrale sole where the projection was occurring very close to the break point in the HCR. I worked around the problem previously by using fixed catches in the forecast file, but a new catch-only projection would benefit from this change to SS3.

Resolves issue #485

## What tests have been done? 
I tested replacing the multiplier 10 in the join function with 100 and 1000. Both produced identical results with OFL*buffer == ACL (identical within the accuracy of the precision of the reported values). Therefore, this PR uses 100 as the multiplier.

This changes shouldn't have a significant impact on model performance because the HCR is only used in projections and therefore doesn't impact the fit to any data.

Model files are attached to issue #485.

## Is there an input change for users to Stock Synthesis? 
[x] No, there was no input change.

## Additional information (optional).
This doesn't solve the larger issue of replacing all the join functions throughout the SS3 code with a single function, but it's not clear how much benefit that would provide.
