### PR TITLE
change settle_seas_offset to work when settlement age is not 0

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -375,7 +375,7 @@
         write_message (NOTE, 0);
       }
       Settle_seas(settle_time) = k;
-      Settle_seas_offset(settle_time) = Settle_seas(settle_time) - spawn_seas + j * nseas; //  number of seasons between spawning and the season in which settlement occurs
+      Settle_seas_offset(settle_time) = Settle_seas(settle_time) - spawn_seas + j * nseas + Settle_age(settle_time) * nseas; //  number of seasons between spawning and the season in which settlement occurs
       Settle_timing_seas(settle_time) -= temp; //  timing from beginning of this season; needed for mortality calculation
       echoinput << settle_time << " / " << Settle_month(settle_time);
       echoinput << "  /  " << Settle_seas(settle_time) << " / " << Settle_seas_offset(settle_time) << " / "


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
See the issue for description of error in timing of time offset between spawning and settlement for certain model configurations
 @alexjensen-NOAA
<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves issue #691 regarding the timing between spawning and settlement when settlement is at age > 0
* clarifies that recdev year refers to the year in which the recruitment was spawned
 @alexjensen-NOAA

## What tests have been done? 
close comparison of results as documented in the issue.

### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->

## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
